### PR TITLE
Mark stack as non-executable

### DIFF
--- a/src/pack_x64.s
+++ b/src/pack_x64.s
@@ -6,6 +6,7 @@
 ##      Distributed under the BSD Software License (see license.txt)      ##
 ############################################################################
 
+        .section .note.GNU-stack,"",@progbits
         .intel_syntax noprefix
         .text
 

--- a/src/pack_x86.s
+++ b/src/pack_x86.s
@@ -6,6 +6,7 @@
 ##      Distributed under the BSD Software License (see license.txt)      ##
 ############################################################################
 
+        .section .note.GNU-stack,"",@progbits
         .intel_syntax noprefix
         .text
 

--- a/src/unpack_armv7.s
+++ b/src/unpack_armv7.s
@@ -6,6 +6,7 @@
 //      Distributed under the BSD Software License (see license.txt)      //
 ////////////////////////////////////////////////////////////////////////////
 
+        .section .note.GNU-stack,"",@progbits
         .text
         .align
         .global         unpack_decorr_stereo_pass_cont_armv7

--- a/src/unpack_x64.s
+++ b/src/unpack_x64.s
@@ -6,6 +6,7 @@
 ##      Distributed under the BSD Software License (see license.txt)      ##
 ############################################################################
 
+        .section .note.GNU-stack,"",@progbits
         .intel_syntax noprefix
         .text
 

--- a/src/unpack_x86.s
+++ b/src/unpack_x86.s
@@ -6,6 +6,7 @@
 ##      Distributed under the BSD Software License (see license.txt)      ##
 ############################################################################
 
+        .section .note.GNU-stack,"",@progbits
         .intel_syntax noprefix
         .text
 


### PR DESCRIPTION
We have received a bug report mentioning that the shared library is built with an executable stack (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=793320 for more details). This PR contains a patch by Russell Coker to remove the executable bit.