### PR TITLE
Fix build for armv7, GNU as uses @ for single-line comments on ARM

### DIFF
--- a/src/unpack_armv7.s
+++ b/src/unpack_armv7.s
@@ -1,10 +1,10 @@
-////////////////////////////////////////////////////////////////////////////
-//                           **** WAVPACK ****                            //
-//                  Hybrid Lossless Wavefile Compressor                   //
-//              Copyright (c) 1998 - 2015 Conifer Software.               //
-//                          All Rights Reserved.                          //
-//      Distributed under the BSD Software License (see license.txt)      //
-////////////////////////////////////////////////////////////////////////////
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@@                           **** WAVPACK ****                            @@
+@@                  Hybrid Lossless Wavefile Compressor                   @@
+@@              Copyright (c) 1998 - 2015 Conifer Software.               @@
+@@                          All Rights Reserved.                          @@
+@@      Distributed under the BSD Software License (see license.txt)      @@
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
         .text
         .align


### PR DESCRIPTION
Build originally failed with:
[..]
unpack_armv7.s: Assembler messages:
unpack_armv7.s:1: Error: junk at end of line, first unrecognized
character is `/'
unpack_armv7.s:2: Error: junk at end of line, first unrecognized
character is `/'
unpack_armv7.s:3: Error: junk at end of line, first unrecognized
character is `/'
unpack_armv7.s:4: Error: junk at end of line, first unrecognized
character is `/'
unpack_armv7.s:5: Error: junk at end of line, first unrecognized
character is `/'
unpack_armv7.s:6: Error: junk at end of line, first unrecognized
character is `/'
unpack_armv7.s:7: Error: junk at end of line, first unrecognized
character is `/'
Makefile:661: recipe for target 'unpack_armv7.lo' failed
[..]