### PR TITLE
enable travis ci build and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 sudo: false
 script:
-  - ./autogen.sh --enable-tests && make && .libs/wvtest --default
+  - ./autogen.sh --enable-tests && make && cli/wvtest --default
 compiler:
   - clang
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: c
 sudo: false
 script:
-  - ./autogen.sh --enable-tests && make && cli/wvtest --default
+  - ./autogen.sh --enable-tests && make && cli/wvtest $WVTEST_ARGS
 compiler:
   - clang
   - gcc
 os:
   - linux
   - osx
+env:
+  matrix:
+    - WVTEST_ARGS=--default --no-hybrid --no-lossy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+sudo: false
+script:
+  - ./autogen.sh --enable-tests && make && .libs/wvtest --default
+compiler:
+  - clang
+  - gcc
+os:
+  - linux
+  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 sudo: false
+dist: trusty
 script:
   - ./autogen.sh --enable-tests && make && cli/wvtest $WVTEST_ARGS
 compiler:
@@ -11,8 +12,3 @@ os:
 env:
   matrix:
     - WVTEST_ARGS="--default --no-hybrid --no-lossy"
-matrix:
-  exclude:
-    # incompatible clang version 3.4 on linux
-    - os: linux
-      compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,8 @@ os:
 env:
   matrix:
     - WVTEST_ARGS="--default --no-hybrid --no-lossy"
+matrix:
+  exclude:
+    # incompatible clang version 3.4 on linux
+    - os: linux
+      compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ os:
   - osx
 env:
   matrix:
-    - WVTEST_ARGS=--default --no-hybrid --no-lossy
+    - WVTEST_ARGS="--default --no-hybrid --no-lossy"


### PR DESCRIPTION
if you're interested, you could enable travis ci on this repo (https://travis-ci.org/stephengroat/WavPack). I know that i currently only have a very small subset of tests running, but I'm not 100% sure how to get the granularity I need for travis (maximum # of jobs is 200, maximum runtime on each job is 50 mins). More tests could be specific by creating more versions of the `WVTEST_ARGS` environment variable

If you're interested, let me know, i'd be interested in helping.

Also could enable automated Windows builds with [appveyor](https://www.appveyor.com/)