### PR TITLE
Fixed compilation errors when using a C++ compiler.

### DIFF
--- a/src/decorr_utils.c
+++ b/src/decorr_utils.c
@@ -32,7 +32,7 @@
 int read_decorr_terms (WavpackStream *wps, WavpackMetadata *wpmd)
 {
     int termcnt = wpmd->byte_length;
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
     struct decorr_pass *dpp;
 
     if (termcnt > MAX_NTERMS)
@@ -61,7 +61,7 @@ int read_decorr_terms (WavpackStream *wps, WavpackMetadata *wpmd)
 int read_decorr_weights (WavpackStream *wps, WavpackMetadata *wpmd)
 {
     int termcnt = wpmd->byte_length, tcount;
-    char *byteptr = wpmd->data;
+    char *byteptr = (char *)wpmd->data;
     struct decorr_pass *dpp;
 
     if (!(wps->wphdr.flags & MONO_DATA))
@@ -93,7 +93,7 @@ int read_decorr_weights (WavpackStream *wps, WavpackMetadata *wpmd)
 
 int read_decorr_samples (WavpackStream *wps, WavpackMetadata *wpmd)
 {
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
     unsigned char *endptr = byteptr + wpmd->byte_length;
     struct decorr_pass *dpp;
     int tcount;
@@ -171,14 +171,14 @@ int read_decorr_samples (WavpackStream *wps, WavpackMetadata *wpmd)
 int read_shaping_info (WavpackStream *wps, WavpackMetadata *wpmd)
 {
     if (wpmd->byte_length == 2) {
-        char *byteptr = wpmd->data;
+        char *byteptr = (char *)wpmd->data;
 
         wps->dc.shaping_acc [0] = (int32_t) restore_weight (*byteptr++) << 16;
         wps->dc.shaping_acc [1] = (int32_t) restore_weight (*byteptr++) << 16;
         return TRUE;
     }
     else if (wpmd->byte_length >= (wps->wphdr.flags & MONO_DATA ? 4 : 8)) {
-        unsigned char *byteptr = wpmd->data;
+        unsigned char *byteptr = (unsigned char *)wpmd->data;
 
         wps->dc.error [0] = wp_exp2s ((int16_t)(byteptr [0] + (byteptr [1] << 8)));
         wps->dc.shaping_acc [0] = wp_exp2s ((int16_t)(byteptr [2] + (byteptr [3] << 8)));

--- a/src/entropy_utils.c
+++ b/src/entropy_utils.c
@@ -110,7 +110,7 @@ static const unsigned char exp2_table [] = {
 
 int read_entropy_vars (WavpackStream *wps, WavpackMetadata *wpmd)
 {
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
 
     if (wpmd->byte_length != ((wps->wphdr.flags & MONO_DATA) ? 6 : 12))
         return FALSE;
@@ -135,7 +135,7 @@ int read_entropy_vars (WavpackStream *wps, WavpackMetadata *wpmd)
 
 int read_hybrid_profile (WavpackStream *wps, WavpackMetadata *wpmd)
 {
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
     unsigned char *endptr = byteptr + wpmd->byte_length;
 
     if (wps->wphdr.flags & HYBRID_BITRATE) {

--- a/src/open_legacy.c
+++ b/src/open_legacy.c
@@ -24,49 +24,49 @@ typedef struct {
 
 static int32_t trans_read_bytes (void *id, void *data, int32_t bcount)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->read_bytes (trans->id, data, bcount);
 }
 
 static int32_t trans_write_bytes (void *id, void *data, int32_t bcount)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->write_bytes (trans->id, data, bcount);
 }
 
 static int64_t trans_get_pos (void *id)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->get_pos (trans->id);
 }
 
 static int trans_set_pos_abs (void *id, int64_t pos)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->set_pos_abs (trans->id, (uint32_t) pos);
 }
 
 static int trans_set_pos_rel (void *id, int64_t delta, int mode)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->set_pos_rel (trans->id, (int32_t) delta, mode);
 }
 
 static int trans_push_back_byte (void *id, int c)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->push_back_byte (trans->id, c);
 }
 
 static int64_t trans_get_length (void *id)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->get_length (trans->id);
 }
 
 static int trans_can_seek (void *id)
 {
-    WavpackReaderTranslator *trans = id;
+    WavpackReaderTranslator *trans = (WavpackReaderTranslator *)id;
     return trans->reader->can_seek (trans->id);
 }
 
@@ -99,13 +99,13 @@ WavpackContext *WavpackOpenFileInputEx (WavpackStreamReader *reader, void *wv_id
         flags |= OPEN_NO_CHECKSUM;
 
     if (wv_id) {
-        trans_wv = malloc (sizeof (WavpackReaderTranslator));
+        trans_wv = (WavpackReaderTranslator *)malloc (sizeof (WavpackReaderTranslator));
         trans_wv->reader = reader;
         trans_wv->id = wv_id;
     }
 
     if (wvc_id) {
-        trans_wvc = malloc (sizeof (WavpackReaderTranslator));
+        trans_wvc = (WavpackReaderTranslator *)malloc (sizeof (WavpackReaderTranslator));
         trans_wvc->reader = reader;
         trans_wvc->id = wvc_id;
     }

--- a/src/open_utils.c
+++ b/src/open_utils.c
@@ -33,7 +33,7 @@ static int seek_eof_information (WavpackContext *wpc, int64_t *final_index, int 
 
 WavpackContext *WavpackOpenFileInputEx64 (WavpackStreamReader64 *reader, void *wv_id, void *wvc_id, char *error, int flags, int norm_offset)
 {
-    WavpackContext *wpc = malloc (sizeof (WavpackContext));
+    WavpackContext *wpc = (WavpackContext *)malloc (sizeof (WavpackContext));
     WavpackStream *wps;
     int num_blocks = 0;
     unsigned char first_byte;
@@ -83,13 +83,13 @@ WavpackContext *WavpackOpenFileInputEx64 (WavpackStreamReader64 *reader, void *w
 #endif
     }
 
-    wpc->streams = malloc ((wpc->num_streams = 1) * sizeof (wpc->streams [0]));
+    wpc->streams = (WavpackStream **)(malloc ((wpc->num_streams = 1) * sizeof (wpc->streams [0])));
     if (!wpc->streams) {
         if (error) strcpy (error, "can't allocate memory");
         return WavpackCloseFile (wpc);
     }
 
-    wpc->streams [0] = wps = malloc (sizeof (WavpackStream));
+    wpc->streams [0] = wps = (WavpackStream *)malloc (sizeof (WavpackStream));
     if (!wps) {
         if (error) strcpy (error, "can't allocate memory");
         return WavpackCloseFile (wpc);
@@ -108,7 +108,7 @@ WavpackContext *WavpackOpenFileInputEx64 (WavpackStreamReader64 *reader, void *w
         }
 
         wpc->filepos += bcount;
-        wps->blockbuff = malloc (wps->wphdr.ckSize + 8);
+        wps->blockbuff = (unsigned char *)malloc (wps->wphdr.ckSize + 8);
         if (!wps->blockbuff) {
             if (error) strcpy (error, "can't allocate memory");
             return WavpackCloseFile (wpc);
@@ -391,7 +391,7 @@ static int init_wvc_bitstream (WavpackStream *wps, WavpackMetadata *wpmd)
 
 static int init_wvx_bitstream (WavpackStream *wps, WavpackMetadata *wpmd)
 {
-    unsigned char *cp = wpmd->data;
+    unsigned char *cp = (unsigned char *)wpmd->data;
 
     if (wpmd->byte_length <= 4 || (wpmd->byte_length & 1))
         return FALSE;
@@ -412,7 +412,7 @@ static int init_wvx_bitstream (WavpackStream *wps, WavpackMetadata *wpmd)
 static int read_int32_info (WavpackStream *wps, WavpackMetadata *wpmd)
 {
     int bytecnt = wpmd->byte_length;
-    char *byteptr = wpmd->data;
+    char *byteptr = (char *)wpmd->data;
 
     if (bytecnt != 4)
         return FALSE;
@@ -428,7 +428,7 @@ static int read_int32_info (WavpackStream *wps, WavpackMetadata *wpmd)
 static int read_float_info (WavpackStream *wps, WavpackMetadata *wpmd)
 {
     int bytecnt = wpmd->byte_length;
-    char *byteptr = wpmd->data;
+    char *byteptr = (char *)wpmd->data;
 
     if (bytecnt != 4)
         return FALSE;
@@ -447,7 +447,7 @@ static int read_float_info (WavpackStream *wps, WavpackMetadata *wpmd)
 static int read_channel_info (WavpackContext *wpc, WavpackMetadata *wpmd)
 {
     int bytecnt = wpmd->byte_length, shift = 0, mask_bits;
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
     uint32_t mask = 0;
 
     if (!bytecnt || bytecnt > 7)
@@ -503,7 +503,7 @@ static int read_channel_info (WavpackContext *wpc, WavpackMetadata *wpmd)
 static int read_channel_identities (WavpackContext *wpc, WavpackMetadata *wpmd)
 {
     if (!wpc->channel_identities) {
-        wpc->channel_identities = malloc (wpmd->byte_length + 1);
+        wpc->channel_identities = (unsigned char *)malloc (wpmd->byte_length + 1);
         memcpy (wpc->channel_identities, wpmd->data, wpmd->byte_length);
         wpc->channel_identities [wpmd->byte_length] = 0;
     }
@@ -516,7 +516,7 @@ static int read_channel_identities (WavpackContext *wpc, WavpackMetadata *wpmd)
 static int read_config_info (WavpackContext *wpc, WavpackMetadata *wpmd)
 {
     int bytecnt = wpmd->byte_length;
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
 
     if (bytecnt >= 3) {
         wpc->config.flags &= 0xff;
@@ -547,7 +547,7 @@ static int read_config_info (WavpackContext *wpc, WavpackMetadata *wpmd)
 static int read_new_config_info (WavpackContext *wpc, WavpackMetadata *wpmd)
 {
     int bytecnt = wpmd->byte_length;
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
 
     wpc->version_five = 1;      // just having this block signals version 5.0
 
@@ -585,7 +585,7 @@ static int read_new_config_info (WavpackContext *wpc, WavpackMetadata *wpmd)
                     if (bytecnt > nchans)
                         return FALSE;
 
-                    wpc->channel_reordering = malloc (nchans);
+                    wpc->channel_reordering = (unsigned char *)malloc (nchans);
 
                     // note that redundant reordering info is not stored, so we fill in the rest
 
@@ -617,7 +617,7 @@ static int read_new_config_info (WavpackContext *wpc, WavpackMetadata *wpmd)
 static int read_sample_rate (WavpackContext *wpc, WavpackMetadata *wpmd)
 {
     int bytecnt = wpmd->byte_length;
-    unsigned char *byteptr = wpmd->data;
+    unsigned char *byteptr = (unsigned char *)wpmd->data;
 
     if (bytecnt == 3 || bytecnt == 4) {
         wpc->config.sample_rate = (int32_t) *byteptr++;
@@ -642,7 +642,7 @@ static int read_sample_rate (WavpackContext *wpc, WavpackMetadata *wpmd)
 static int read_wrapper_data (WavpackContext *wpc, WavpackMetadata *wpmd)
 {
     if ((wpc->open_flags & OPEN_WRAPPER) && wpc->wrapper_bytes < MAX_WRAPPER_BYTES && wpmd->byte_length) {
-        wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + wpmd->byte_length);
+        wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + wpmd->byte_length);
 	if (!wpc->wrapper_data)
 	    return FALSE;
         memcpy (wpc->wrapper_data + wpc->wrapper_bytes, wpmd->data, wpmd->byte_length);
@@ -808,8 +808,8 @@ static void bs_read (Bitstream *bs);
 static void bs_open_read (Bitstream *bs, void *buffer_start, void *buffer_end)
 {
     bs->error = bs->sr = bs->bc = 0;
-    bs->ptr = (bs->buf = buffer_start) - 1;
-    bs->end = buffer_end;
+    bs->ptr = ((bs->buf = (uint16_t *)buffer_start) - 1);
+    bs->end = (uint16_t *)buffer_end;
     bs->wrap = bs_read;
 }
 
@@ -994,7 +994,7 @@ int read_wvc_block (WavpackContext *wpc)
         compare_result = match_wvc_header (&wps->wphdr, &wphdr);
 
         if (!compare_result) {
-            wps->block2buff = malloc (wphdr.ckSize + 8);
+            wps->block2buff = (unsigned char *)malloc (wphdr.ckSize + 8);
 	    if (!wps->block2buff)
 	        return FALSE;
 
@@ -1158,7 +1158,7 @@ static int seek_eof_information (WavpackContext *wpc, int64_t *final_index, int 
             meta_id &= ID_UNIQUE;
 
             if (get_wrapper && (meta_id == ID_RIFF_TRAILER || (alt_types && meta_id == ID_ALT_TRAILER)) && meta_bc) {
-                wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + meta_bc);
+                wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + meta_bc);
 
                 if (!wpc->wrapper_data) {
                     reader->set_pos_abs (id, restore_pos);

--- a/src/tag_utils.c
+++ b/src/tag_utils.c
@@ -429,7 +429,7 @@ static int append_ape_tag_item (WavpackContext *wpc, const char *item, const cha
 
         m_tag->ape_tag_hdr.item_count++;
         m_tag->ape_tag_hdr.length += new_item_len;
-        p = m_tag->ape_tag_data = realloc (m_tag->ape_tag_data, m_tag->ape_tag_hdr.length);
+        p = m_tag->ape_tag_data = (unsigned char*)realloc (m_tag->ape_tag_data, m_tag->ape_tag_hdr.length);
         p += m_tag->ape_tag_hdr.length - sizeof (APE_Tag_Hdr) - new_item_len;
 
         *p++ = (unsigned char) vsize;

--- a/src/tags.c
+++ b/src/tags.c
@@ -59,7 +59,7 @@ int load_tag (WavpackContext *wpc)
                 if (m_tag->ape_tag_hdr.version == 2000 && m_tag->ape_tag_hdr.item_count &&
                     m_tag->ape_tag_hdr.length > sizeof (m_tag->ape_tag_hdr) &&
                     m_tag->ape_tag_hdr.length <= APE_TAG_MAX_LENGTH &&
-                    (m_tag->ape_tag_data = malloc (m_tag->ape_tag_hdr.length)) != NULL) {
+                    (m_tag->ape_tag_data = (unsigned char *)malloc (m_tag->ape_tag_hdr.length)) != NULL) {
 
                         ape_tag_items = m_tag->ape_tag_hdr.item_count;
                         ape_tag_length = m_tag->ape_tag_hdr.length;

--- a/src/unpack3.c
+++ b/src/unpack3.c
@@ -1174,11 +1174,11 @@ int32_t unpack_samples3 (WavpackContext *wpc, int32_t *buffer, uint32_t sample_c
             wpc->crc_errors++;
 
         if (wpc->open_flags & OPEN_WRAPPER) {
-            unsigned char *temp = malloc (1024);
+            unsigned char *temp = (unsigned char *)malloc (1024);
             uint32_t bcount;
 
             if (bs_unused_bytes (&wps->wvbits)) {
-                wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + bs_unused_bytes (&wps->wvbits));
+                wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + bs_unused_bytes (&wps->wvbits));
                 memcpy (wpc->wrapper_data + wpc->wrapper_bytes, bs_unused_data (&wps->wvbits), bs_unused_bytes (&wps->wvbits));
                 wpc->wrapper_bytes += bs_unused_bytes (&wps->wvbits);
             }
@@ -1189,7 +1189,7 @@ int32_t unpack_samples3 (WavpackContext *wpc, int32_t *buffer, uint32_t sample_c
                 if (!bcount)
                     break;
 
-                wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + bcount);
+                wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + bcount);
                 memcpy (wpc->wrapper_data + wpc->wrapper_bytes, temp, bcount);
                 wpc->wrapper_bytes += bcount;
             }

--- a/src/unpack3_open.c
+++ b/src/unpack3_open.c
@@ -53,7 +53,7 @@ WavpackContext *open_file3 (WavpackContext *wpc, char *error)
     if (!strncmp (RiffChunkHeader.ckID, "RIFF", 4) && !strncmp (RiffChunkHeader.formType, "WAVE", 4)) {
 
         if (wpc->open_flags & OPEN_WRAPPER) {
-            wpc->wrapper_data = malloc (wpc->wrapper_bytes = sizeof (RiffChunkHeader));
+            wpc->wrapper_data = (unsigned char *)malloc (wpc->wrapper_bytes = sizeof (RiffChunkHeader));
             memcpy (wpc->wrapper_data, &RiffChunkHeader, sizeof (RiffChunkHeader));
         }
 
@@ -71,7 +71,7 @@ WavpackContext *open_file3 (WavpackContext *wpc, char *error)
             }
             else {
                 if (wpc->open_flags & OPEN_WRAPPER) {
-                    wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + sizeof (ChunkHeader));
+                    wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + sizeof (ChunkHeader));
                     memcpy (wpc->wrapper_data + wpc->wrapper_bytes, &ChunkHeader, sizeof (ChunkHeader));
                     wpc->wrapper_bytes += sizeof (ChunkHeader);
                 }
@@ -86,7 +86,7 @@ WavpackContext *open_file3 (WavpackContext *wpc, char *error)
                             return WavpackCloseFile (wpc);
                     }
                     else if (wpc->open_flags & OPEN_WRAPPER) {
-                        wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + sizeof (wavhdr));
+                        wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + sizeof (wavhdr));
                         memcpy (wpc->wrapper_data + wpc->wrapper_bytes, &wavhdr, sizeof (wavhdr));
                         wpc->wrapper_bytes += sizeof (wavhdr);
                     }
@@ -102,12 +102,12 @@ WavpackContext *open_file3 (WavpackContext *wpc, char *error)
                         }
 
                         if (wpc->open_flags & OPEN_WRAPPER) {
-                            wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + bytes_to_skip);
+                            wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + bytes_to_skip);
                             wpc->reader->read_bytes (wpc->wv_in, wpc->wrapper_data + wpc->wrapper_bytes, bytes_to_skip);
                             wpc->wrapper_bytes += bytes_to_skip;
                         }
                         else {
-                            unsigned char *temp = malloc (bytes_to_skip);
+                            unsigned char *temp = (unsigned char *)malloc (bytes_to_skip);
                             wpc->reader->read_bytes (wpc->wv_in, temp, bytes_to_skip);
                             free (temp);
                         }
@@ -124,12 +124,12 @@ WavpackContext *open_file3 (WavpackContext *wpc, char *error)
                     }
 
                     if (wpc->open_flags & OPEN_WRAPPER) {
-                        wpc->wrapper_data = realloc (wpc->wrapper_data, wpc->wrapper_bytes + bytes_to_skip);
+                        wpc->wrapper_data = (unsigned char *)realloc (wpc->wrapper_data, wpc->wrapper_bytes + bytes_to_skip);
                         wpc->reader->read_bytes (wpc->wv_in, wpc->wrapper_data + wpc->wrapper_bytes, bytes_to_skip);
                         wpc->wrapper_bytes += bytes_to_skip;
                     }
                     else {
-                        unsigned char *temp = malloc (bytes_to_skip);
+                        unsigned char *temp = (unsigned char *)malloc (bytes_to_skip);
                         wpc->reader->read_bytes (wpc->wv_in, temp, bytes_to_skip);
                         free (temp);
                     }

--- a/src/unpack_dsd.c
+++ b/src/unpack_dsd.c
@@ -34,7 +34,7 @@ int init_dsd_block (WavpackContext *wpc, WavpackMetadata *wpmd)
     if (wpmd->byte_length < 2)
         return FALSE;
 
-    wps->dsd.byteptr = wpmd->data;
+    wps->dsd.byteptr = (unsigned char *)wpmd->data;
     wps->dsd.endptr = wps->dsd.byteptr + wpmd->byte_length;
     wpc->dsd_multiplier = 1 << *wps->dsd.byteptr++;
     wps->dsd.mode = *wps->dsd.byteptr++;
@@ -141,10 +141,10 @@ static int init_dsd_block_fast (WavpackStream *wps, WavpackMetadata *wpmd)
 
     wps->dsd.history_bins = 1 << history_bits;
 
-    wps->dsd.value_lookup = malloc (sizeof (*wps->dsd.value_lookup) * wps->dsd.history_bins);
+    wps->dsd.value_lookup = (unsigned char **)malloc (sizeof (*wps->dsd.value_lookup) * wps->dsd.history_bins);
     memset (wps->dsd.value_lookup, 0, sizeof (*wps->dsd.value_lookup) * wps->dsd.history_bins);
-    wps->dsd.summed_probabilities = malloc (sizeof (*wps->dsd.summed_probabilities) * wps->dsd.history_bins);
-    wps->dsd.probabilities = malloc (sizeof (*wps->dsd.probabilities) * wps->dsd.history_bins);
+    wps->dsd.summed_probabilities = (int16_t (*)[256])malloc (sizeof (*wps->dsd.summed_probabilities) * wps->dsd.history_bins);
+    wps->dsd.probabilities = (unsigned char (*)[256])malloc (sizeof (*wps->dsd.probabilities) * wps->dsd.history_bins);
 
     max_probability = *wps->dsd.byteptr++;
 
@@ -186,7 +186,7 @@ static int init_dsd_block_fast (WavpackStream *wps, WavpackMetadata *wpmd)
 
         if (sum_values) {
             total_summed_probabilities += sum_values;
-            vp = wps->dsd.value_lookup [wps->dsd.p0] = malloc (sum_values);
+            vp = wps->dsd.value_lookup [wps->dsd.p0] = (unsigned char *)malloc (sum_values);
 
             for (i = 0; i < 256; i++) {
                 int c = wps->dsd.probabilities [wps->dsd.p0] [i];
@@ -316,7 +316,7 @@ static int init_dsd_block_high (WavpackStream *wps, WavpackMetadata *wpmd)
     if (rate_s != RATE_S)
         return FALSE;
 
-    wps->dsd.ptable = malloc (PTABLE_BINS * sizeof (*wps->dsd.ptable));
+    wps->dsd.ptable = (int32_t *)malloc (PTABLE_BINS * sizeof (*wps->dsd.ptable));
     init_ptable (wps->dsd.ptable, rate_i, rate_s);
 
     for (channel = 0; channel < ((flags & MONO_DATA) ? 1 : 2); ++channel) {
@@ -495,7 +495,7 @@ typedef struct {
 
 void *decimate_dsd_init (int num_channels)
 {
-    DecimationContext *context = malloc (sizeof (DecimationContext));
+    DecimationContext *context = (DecimationContext *)malloc (sizeof (DecimationContext));
     double filter_sum = 0, filter_scale;
     int skipped_terms, i, j;
 
@@ -504,7 +504,7 @@ void *decimate_dsd_init (int num_channels)
 
     memset (context, 0, sizeof (*context));
     context->num_channels = num_channels;
-    context->chans = malloc (num_channels * sizeof (DecimationChannel));
+    context->chans = (DecimationChannel *)malloc (num_channels * sizeof (DecimationChannel));
 
     if (!context->chans) {
         free (context);

--- a/src/unpack_seek.c
+++ b/src/unpack_seek.c
@@ -85,7 +85,7 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
         wpc->reader->set_pos_abs (wpc->wv_in, wpc->filepos);
         wpc->reader->read_bytes (wpc->wv_in, &wps->wphdr, sizeof (WavpackHeader));
         WavpackLittleEndianToNative (&wps->wphdr, WavpackHeaderFormat);
-        wps->blockbuff = malloc (wps->wphdr.ckSize + 8);
+        wps->blockbuff = (unsigned char *)malloc (wps->wphdr.ckSize + 8);
         memcpy (wps->blockbuff, &wps->wphdr, sizeof (WavpackHeader));
 
         if (wpc->reader->read_bytes (wpc->wv_in, wps->blockbuff + sizeof (WavpackHeader), wps->wphdr.ckSize - 24) !=
@@ -109,7 +109,7 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
             wpc->reader->set_pos_abs (wpc->wvc_in, wpc->file2pos);
             wpc->reader->read_bytes (wpc->wvc_in, &wps->wphdr, sizeof (WavpackHeader));
             WavpackLittleEndianToNative (&wps->wphdr, WavpackHeaderFormat);
-            wps->block2buff = malloc (wps->wphdr.ckSize + 8);
+            wps->block2buff = (unsigned char *)malloc (wps->wphdr.ckSize + 8);
             memcpy (wps->block2buff, &wps->wphdr, sizeof (WavpackHeader));
 
             if (wpc->reader->read_bytes (wpc->wvc_in, wps->block2buff + sizeof (WavpackHeader), wps->wphdr.ckSize - 24) !=
@@ -145,8 +145,8 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
                 return FALSE;
             }
 
-            wpc->streams = realloc (wpc->streams, (wpc->num_streams + 1) * sizeof (wpc->streams [0]));
-            wps = wpc->streams [wpc->num_streams++] = malloc (sizeof (WavpackStream));
+            wpc->streams = (WavpackStream **)realloc (wpc->streams, (wpc->num_streams + 1) * sizeof (wpc->streams [0]));
+            wps = wpc->streams [wpc->num_streams++] = (WavpackStream *)malloc (sizeof (WavpackStream));
             CLEAR (*wps);
             bcount = read_next_header (wpc->reader, wpc->wv_in, &wps->wphdr);
 
@@ -155,7 +155,7 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
                 return FALSE;
             }
 
-            wps->blockbuff = malloc (wps->wphdr.ckSize + 8);
+            wps->blockbuff = (unsigned char *)malloc (wps->wphdr.ckSize + 8);
             memcpy (wps->blockbuff, &wps->wphdr, 32);
 
             if (wpc->reader->read_bytes (wpc->wv_in, wps->blockbuff + 32, wps->wphdr.ckSize - 24) !=
@@ -205,7 +205,7 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
     }
 
     if (samples_to_skip) {
-        buffer = malloc (samples_to_skip * 8);
+        buffer = (int32_t *)malloc (samples_to_skip * 8);
 
         for (wpc->current_stream = 0; wpc->current_stream < wpc->num_streams; wpc->current_stream++)
 #ifdef ENABLE_DSD
@@ -225,7 +225,7 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
         decimate_dsd_reset (wpc->decimation_context);
 
     if (samples_to_decode) {
-        buffer = malloc (samples_to_decode * wpc->config.num_channels * 4);
+        buffer = (int32_t *)malloc (samples_to_decode * wpc->config.num_channels * 4);
 
         if (buffer) {
             WavpackUnpackSamples (wpc, buffer, samples_to_decode);
@@ -248,7 +248,7 @@ int WavpackSeekSample64 (WavpackContext *wpc, int64_t sample)
 
 static int64_t find_header (WavpackStreamReader64 *reader, void *id, int64_t filepos, WavpackHeader *wphdr)
 {
-    unsigned char *buffer = malloc (BUFSIZE), *sp = buffer, *ep = buffer;
+    unsigned char *buffer = (unsigned char *)malloc (BUFSIZE), *sp = buffer, *ep = buffer;
 
     if (filepos != (uint32_t) -1 && reader->set_pos_abs (id, filepos)) {
         free (buffer);

--- a/src/unpack_utils.c
+++ b/src/unpack_utils.c
@@ -71,7 +71,7 @@ uint32_t WavpackUnpackSamples (WavpackContext *wpc, int32_t *buffer, uint32_t sa
 
                 // allocate the memory for the entire raw block and read it in
 
-                wps->blockbuff = malloc (wps->wphdr.ckSize + 8);
+                wps->blockbuff = (unsigned char *)malloc (wps->wphdr.ckSize + 8);
 
                 if (!wps->blockbuff)
                     break;
@@ -178,7 +178,7 @@ uint32_t WavpackUnpackSamples (WavpackContext *wpc, int32_t *buffer, uint32_t sa
         // to stereo), then enter this conditional block...otherwise we just unpack the samples directly
 
         if (!wpc->reduced_channels && !(wps->wphdr.flags & FINAL_BLOCK)) {
-            int32_t *temp_buffer = malloc (samples_to_unpack * 8), *src, *dst;
+            int32_t *temp_buffer = (int32_t *)malloc (samples_to_unpack * 8), *src, *dst;
             int offset = 0;     // offset to next channel in sequence (0 to num_channels - 1)
             uint32_t samcnt;
 
@@ -195,12 +195,12 @@ uint32_t WavpackUnpackSamples (WavpackContext *wpc, int32_t *buffer, uint32_t sa
                 // if the stream has not been allocated and corresponding block read, do that here...
 
                 if (wpc->current_stream == wpc->num_streams) {
-                    wpc->streams = realloc (wpc->streams, (wpc->num_streams + 1) * sizeof (wpc->streams [0]));
+                    wpc->streams = (WavpackStream **)realloc (wpc->streams, (wpc->num_streams + 1) * sizeof (wpc->streams [0]));
 
                     if (!wpc->streams)
 			break;
 
-                    wps = wpc->streams [wpc->num_streams++] = malloc (sizeof (WavpackStream));
+                    wps = wpc->streams [wpc->num_streams++] = (WavpackStream *)malloc (sizeof (WavpackStream));
 
                     if (!wps)
 			break;
@@ -215,7 +215,7 @@ uint32_t WavpackUnpackSamples (WavpackContext *wpc, int32_t *buffer, uint32_t sa
                         break;
                     }
 
-                    wps->blockbuff = malloc (wps->wphdr.ckSize + 8);
+                    wps->blockbuff = (unsigned char *)malloc (wps->wphdr.ckSize + 8);
 
                     if (!wps->blockbuff)
 		        break;


### PR DESCRIPTION
## What have I done?

In order to compile the C code in a C++ project, I've had to C-style cast anything that was of type `void*` to the destination type.

The issue we were running into is the blasted [error C2440](https://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k(C2440)&rd=true).

## Why have I done this? What was I trying to do?

A bit of background: I'm a C++ developer using [JUCE](https://github.com/WeAreROLI/JUCE). In-house at [AudioWorks](https://github.com/Audioworks) we have our own [Unity Build modules](http://buffered.io/posts/the-magic-of-unity-builds/), following similar conventions to JUCE's modules.

We are trying to use this repository as a submodule in order to avoid the whole _Not Invented Here_ problem, and having a facilitated way of keeping up to date. To do this, we have wrapped WavPack's source in a derived implementation of [`juce::AudioFormatReader`](https://www.juce.com/doc/classAudioFormatReader) using a similar approach to JUCE's [OGG](https://github.com/WeAreROLI/JUCE/blob/master/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp#L52-L78) and [FLAC ](https://github.com/WeAreROLI/JUCE/blob/master/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp#L137-L152) support: including the `.c` files directly.
***

If my pull request is completely missing the mark, or if I've gone about this the wrong way (eg: not quite 'getting' C, coding style, wrong repo), let me know what I need to change - assuming you're interested.

...and if the motivation is too left-field, feel free to close the pull request.

Cheers!