### PR TITLE
x64 ASM support for midipix

### DIFF
--- a/src/extra1.c
+++ b/src/extra1.c
@@ -36,7 +36,7 @@
 
 #ifdef OPT_ASM_X86
     #define PACK_DECORR_MONO_PASS_CONT pack_decorr_mono_pass_cont_x86
-#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__))
+#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__) || defined(__midipix__))
     #define PACK_DECORR_MONO_PASS_CONT pack_decorr_mono_pass_cont_x64win
 #elif defined(OPT_ASM_X64)
     #define PACK_DECORR_MONO_PASS_CONT pack_decorr_mono_pass_cont_x64

--- a/src/extra2.c
+++ b/src/extra2.c
@@ -39,7 +39,7 @@
     #define PACK_DECORR_STEREO_PASS_CONT pack_decorr_stereo_pass_cont_x86
     #define PACK_DECORR_STEREO_PASS_CONT_REV pack_decorr_stereo_pass_cont_rev_x86
     #define PACK_DECORR_STEREO_PASS_CONT_AVAILABLE pack_cpu_has_feature_x86(CPU_FEATURE_MMX)
-#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__))
+#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__) || defined(__midipix__))
     #define PACK_DECORR_STEREO_PASS_CONT pack_decorr_stereo_pass_cont_x64win
     #define PACK_DECORR_STEREO_PASS_CONT_REV pack_decorr_stereo_pass_cont_rev_x64win
     #define PACK_DECORR_STEREO_PASS_CONT_AVAILABLE 1

--- a/src/pack.c
+++ b/src/pack.c
@@ -959,7 +959,7 @@ void send_general_metadata (WavpackContext *wpc)
         (pack_cpu_has_feature_x86 (CPU_FEATURE_MMX) ?   \
             scan_max_magnitude_x86 (a, b) :             \
             scan_max_magnitude (a, b))
-#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__))
+#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__) || defined(__midipix__))
     #define DECORR_STEREO_PASS pack_decorr_stereo_pass_x64win
     #define DECORR_MONO_BUFFER pack_decorr_mono_buffer_x64win
     #define SCAN_MAX_MAGNITUDE scan_max_magnitude_x64win

--- a/src/pack_x64.S
+++ b/src/pack_x64.S
@@ -1939,3 +1939,46 @@ normal_exit:
         .section .note.GNU-stack,"",@progbits
 #endif
 
+#ifdef __midipix__
+	.section .got$log2buffer_x64win,"r"
+	.global __imp_log2buffer_x64win
+__imp_log2buffer_x64win:
+	.quad	log2buffer_x64win
+	.linkonce discard
+
+	.section .got$pack_decorr_mono_pass_cont_x64win,"r"
+	.global __imp_pack_decorr_mono_pass_cont_x64win
+__imp_pack_decorr_mono_pass_cont_x64win:
+	.quad	pack_decorr_mono_pass_cont_x64win
+	.linkonce discard
+
+	.section .got$pack_decorr_stereo_pass_cont_x64win,"r"
+	.global __imp_pack_decorr_stereo_pass_cont_x64win
+__imp_pack_decorr_stereo_pass_cont_x64win:
+	.quad	pack_decorr_stereo_pass_cont_x64win
+	.linkonce discard
+
+	.section .got$pack_decorr_stereo_pass_cont_rev_x64win,"r"
+	.global __imp_pack_decorr_stereo_pass_cont_rev_x64win
+__imp_pack_decorr_stereo_pass_cont_rev_x64win:
+	.quad	pack_decorr_stereo_pass_cont_rev_x64win
+	.linkonce discard
+
+	.section .got$pack_decorr_stereo_pass_x64win,"r"
+	.global __imp_pack_decorr_stereo_pass_x64win
+__imp_pack_decorr_stereo_pass_x64win:
+	.quad	pack_decorr_stereo_pass_x64win
+	.linkonce discard
+
+	.section .got$scan_max_magnitude_x64win,"r"
+	.global __imp_scan_max_magnitude_x64win
+__imp_scan_max_magnitude_x64win:
+	.quad scan_max_magnitude_x64win
+	.linkonce discard
+
+	.section .got$pack_decorr_mono_buffer_x64win,"r"
+	.global __imp_pack_decorr_mono_buffer_x64win
+__imp_pack_decorr_mono_buffer_x64win:
+	.quad pack_decorr_mono_buffer_x64win
+	.linkonce discard
+#endif

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -22,7 +22,7 @@
     #define DECORR_STEREO_PASS_CONT unpack_decorr_stereo_pass_cont_x86
     #define DECORR_STEREO_PASS_CONT_AVAILABLE unpack_cpu_has_feature_x86(CPU_FEATURE_MMX)
     #define DECORR_MONO_PASS_CONT unpack_decorr_mono_pass_cont_x86
-#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__))
+#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__) || defined(__midipix__))
     #define DECORR_STEREO_PASS_CONT unpack_decorr_stereo_pass_cont_x64win
     #define DECORR_STEREO_PASS_CONT_AVAILABLE 1
     #define DECORR_MONO_PASS_CONT unpack_decorr_mono_pass_cont_x64win

--- a/src/unpack_x64.S
+++ b/src/unpack_x64.S
@@ -955,3 +955,16 @@ mono_done:
         .section .note.GNU-stack,"",@progbits
 #endif
 
+#ifdef __midipix__
+	.section .got$unpack_decorr_mono_pass_cont_x64win,"r"
+	.global __imp_unpack_decorr_mono_pass_cont_x64win
+__imp_unpack_decorr_mono_pass_cont_x64win:
+	.quad	unpack_decorr_mono_pass_cont_x64win
+	.linkonce discard
+
+	.section .got$unpack_decorr_stereo_pass_cont_x64win,"r"
+	.global __imp_unpack_decorr_stereo_pass_cont_x64win
+__imp_unpack_decorr_stereo_pass_cont_x64win:
+	.quad	unpack_decorr_stereo_pass_cont_x64win
+	.linkonce discard
+#endif

--- a/src/wavpack_local.h
+++ b/src/wavpack_local.h
@@ -749,7 +749,7 @@ int FASTCALL wp_log2 (uint32_t avalue);
 
 #ifdef OPT_ASM_X86
 #define LOG2BUFFER log2buffer_x86
-#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__))
+#elif defined(OPT_ASM_X64) && (defined (_WIN64) || defined(__CYGWIN__) || defined(__MINGW64__) || defined(__midipix__))
 #define LOG2BUFFER log2buffer_x64win
 #elif defined(OPT_ASM_X64)
 #define LOG2BUFFER log2buffer_x64


### PR DESCRIPTION
This adds support for building on midipix with the manually written ASM routines, only 64-bit version for now, as 32-bit doesn't compile yet, so I can't test it...