### PR TITLE
cli: Fix build with slibtool.

### DIFF
--- a/cli/Makefile.am
+++ b/cli/Makefile.am
@@ -8,7 +8,7 @@ wavpack_CFLAGS = $(AM_CFLAGS) $(ICONV_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 wavpack_LDFLAGS = -rpath $(libdir)
 endif
-wavpack_LDADD = $(AM_LDADD) $(top_builddir)/src/.libs/libwavpack.la $(LIBM) $(ICONV_LIBS)
+wavpack_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM) $(ICONV_LIBS)
 
 wvunpack_SOURCES = wvunpack.c riff.c wave64.c caff.c dsdiff.c dsf.c utils.c md5.c
 if WINDOWS_HOST
@@ -18,7 +18,7 @@ wvunpack_CFLAGS = $(AM_CFLAGS) $(ICONV_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 wvunpack_LDFLAGS = -rpath $(libdir)
 endif
-wvunpack_LDADD = $(AM_LDADD) $(top_builddir)/src/.libs/libwavpack.la $(LIBM) $(ICONV_LIBS)
+wvunpack_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM) $(ICONV_LIBS)
 
 wvgain_SOURCES = wvgain.c utils.c
 if WINDOWS_HOST
@@ -28,7 +28,7 @@ wvgain_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 wvgain_LDFLAGS = -rpath $(libdir)
 endif
-wvgain_LDADD = $(AM_LDADD) $(top_builddir)/src/.libs/libwavpack.la $(LIBM)
+wvgain_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM)
 
 wvtag_SOURCES = wvtag.c utils.c import_id3.c
 if WINDOWS_HOST
@@ -38,7 +38,7 @@ wvtag_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 wvtag_LDFLAGS = -rpath $(libdir)
 endif
-wvtag_LDADD = $(AM_LDADD) $(top_builddir)/src/.libs/libwavpack.la $(LIBM) $(ICONV_LIBS)
+wvtag_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM) $(ICONV_LIBS)
 
 if ENABLE_TESTS
 bin_PROGRAMS += wvtest
@@ -47,7 +47,7 @@ wvtest_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 wvtest_LDFLAGS = -rpath $(libdir)
 endif
-wvtest_LDADD = $(AM_LDADD) $(top_builddir)/src/.libs/libwavpack.la $(LIBM) -lpthread
+wvtest_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM) -lpthread
 endif
 
 noinst_HEADERS = \


### PR DESCRIPTION
The `.libs` directory is an internal libtool directory which build projects should not directly use. With libtool it will happen to work because it parses the actual file, but with other implementations such as slibtool it will fail because it relies a `.deps` file found in the same directory as the `.la` file which will not be found.

Instead of using the the symlinked `.la` file in the `.libs` directory its better to use the file the symlink points to and this will allow greater portability for building WavPack.

For reference here is the current build error with slibtool:
```
rdlibtool --tag=CC --mode=link gcc -I../include -g -O2 -o wavpack wavpack-wavpack.o wavpack-riff.o wavpack-wave64.o wavpack-caff.o wavpack-dsdiff.o wavpack-dsf.o wavpack-utils.o wavpack-md5.o wavpack-import_id3.o ../src/.libs/libwavpack.la -lm -lcrypto

rdlibtool: error logged in slbt_get_deps_meta(), line 125: No such file or directory.
rdlibtool: < returned to > slbt_exec_link_create_executable(), line 1463.
rdlibtool: < returned to > slbt_exec_link(), line 1845.
make[1]: *** [Makefile:509: wavpack] Error 2
make[1]: Leaving directory '/tmp/WavPack/cli'
make: *** [Makefile:457: all-recursive] Error 1
```
And the slibtool repo and documentation can be found here.
https://git.midipix.org/cgit.cgi/slibtool/