### PR TITLE
restrict _BitScanForward to msvc

### DIFF
--- a/src/read_words.c
+++ b/src/read_words.c
@@ -124,7 +124,7 @@ int32_t FASTCALL get_word (WavpackStream *wps, int chan, int32_t *correction)
             wps->wvbits.bc += sizeof (*(wps->wvbits.ptr)) * 8;
         }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
         { unsigned long res; _BitScanForward (&res, (unsigned long)~wps->wvbits.sr); ones_count = (uint32_t) res; }
 #else
         ones_count = __builtin_ctz (~wps->wvbits.sr);
@@ -403,7 +403,7 @@ int32_t get_words_lossless (WavpackStream *wps, int32_t *buffer, int32_t nsample
             bs->bc += sizeof (*(bs->ptr)) * 8;
         }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
         { unsigned long res; _BitScanForward (&res, (unsigned long)~wps->wvbits.sr); ones_count = (uint32_t) res; }
 #else
         ones_count = __builtin_ctz (~wps->wvbits.sr);


### PR DESCRIPTION
This should eliminate the _implicit declaration_ warning during MinGW build. MinGW has the `__builtin_ctz` function and defines `_WIN32` too. By some unknown magic it produces working executable even without the change, but with the change we get rid of the warning and the produced executable is a little bit smaller.

BTW here
https://github.com/dbry/WavPack/blob/a07f314ae89092362211a6f982e27c83febec086/src/read_words.c#L32

you restrict `_BitScanForward` only to win64 not sure why, i think it should work for win32 too (haven't tested though).