### PR TITLE
Fix Bitstream alignment problem

### DIFF
--- a/src/open_utils.c
+++ b/src/open_utils.c
@@ -809,7 +809,7 @@ static void bs_open_read (Bitstream *bs, void *buffer_start, void *buffer_end)
 {
     bs->error = bs->sr = bs->bc = 0;
     bs->ptr = ((bs->buf = (uint16_t *)buffer_start) - 1);
-    bs->end = (uint16_t *)buffer_end;
+    bs->end = (void *)(sizeof(*bs->ptr)*((uintptr_t)buffer_end/sizeof(*bs->ptr)));
     bs->wrap = bs_read;
 }
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -1685,7 +1685,7 @@ static void bs_open_write (Bitstream *bs, void *buffer_start, void *buffer_end)
 {
     bs->error = bs->sr = bs->bc = 0;
     bs->ptr = bs->buf = buffer_start;
-    bs->end = buffer_end;
+    bs->end = (void *)(sizeof(*bs->ptr)*((uintptr_t)buffer_end/sizeof(*bs->ptr)));
     bs->wrap = bs_write;
 }
 


### PR DESCRIPTION
While doing a CVE study, I was looking at CVE-2018-10536 in wavpack and discovered another issue. The overflow in that CVE is when the putbits macro (wavpack_local.h) is used, but examining the macro it appears that a check is included so that it will not write past the end of the buffer. In particular, after advancing bs->ptr, it checks if bs->ptr==bs->end. Clearly this wasn't working properly because of the buffer overflow.

A little investigation showed that this is an alignment issue. The buffer is allocated as a block of bytes, but then cast to a (uint16_t *) to initialize bs->ptr. This then is stepped by 2's, since 16-bits at a time are added to the buffer. However, the bs->end pointer might not be aligned the same way, so bs->ptr can skip right past it (the equality test never notices).

A small test case shows this status for the bitstream object:

$3 = {buf = 0x5555557753ee, end = 0x5555557758df, ptr = 0x5555557753ee, 
  wrap = 0x7ffff7bb2af7 <bs_write>, error = 0, bc = 0, sr = 0}

Since "end" is odd and "ptr" is even and advanced by 2's, the two will never be equal, and ptr will advance right past end.

The proposed fix rounds down the "end" pointer to the proper alignment when the Bitstream is initialized (two places). The code is a little ugly, but is general purpose and should always work.

The buffer end test is really a backup check, and the rest of the code is designed so that the buffer should never fill up. However, it's a good backup test for safety, so it's important that it work correctly!

