### PR TITLE
configure.ac: fix --disable-man

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,7 @@ fi
 
 AC_ARG_ENABLE(man,
               [AC_HELP_STRING([--enable-man],
-                              [regenerate man pages from Docbook [default=no]])],enable_man=yes,
+                              [regenerate man pages from Docbook [default=no]])],enable_man=$enableval,
               enable_man=no)
 
 if test "${enable_man}" != no; then


### PR DESCRIPTION
$enableval should be used to know if the user has passed --enable-man or
--disable-man

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>