### PR TITLE
Autotools update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ before_install:
 script:
   - if [[ "${BUILD_SYSTEM}" == "cmake" ]]; then mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON && cmake --build . && cpack -G ZIP && ctest -V; fi
   - if [[ "${BUILD_SYSTEM}" == "autotools" && "${TRAVIS_OS_NAME}" == "linux" && "${CC_FOR_BUILD}" == "clang" ]]; then ./build-regressors.sh && ./run-regressors.sh; fi
-  - if [[ "${BUILD_SYSTEM}" == "autotools" && ( "${TRAVIS_OS_NAME}" != "linux" || "${CC_FOR_BUILD}" != "clang" ) ]]; then ./autogen.sh --enable-tests && make && cli/wvtest --exhaustive --short --no-extras; fi
+  - if [[ "${BUILD_SYSTEM}" == "autotools" && ( "${TRAVIS_OS_NAME}" != "linux" || "${CC_FOR_BUILD}" != "clang" ) ]]; then ./autogen.sh && make distcheck; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,9 @@ MAINTAINERCLEANFILES = \
 	missing \
 	install-sh
 
-EXTRA_DIST = README.md doc/*.pdf doc/*.html doc/*.css \
+EXTRA_DIST = README.md \
+	doc/WavPack5FileFormat.pdf doc/WavPack5LibraryDoc.pdf doc/WavPack5PortingGuide.pdf \
+	doc/wavpack_doc.html doc/style.css \
 	CMakeLists.txt cmake/CheckCLinkerFlag.cmake cmake/modules/FindIconv.cmake \
 	cmake/TestLargeFiles.cmake
 

--- a/cli/Makefile.am
+++ b/cli/Makefile.am
@@ -40,15 +40,16 @@ wvtag_LDFLAGS = -rpath $(libdir)
 endif
 wvtag_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM) $(ICONV_LIBS)
 
-if ENABLE_TESTS
-bin_PROGRAMS += wvtest
+check_PROGRAMS = wvtest
 wvtest_SOURCES = wvtest.c md5.c
 wvtest_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 wvtest_LDFLAGS = -rpath $(libdir)
 endif
 wvtest_LDADD = $(AM_LDADD) $(top_builddir)/src/libwavpack.la $(LIBM) -lpthread
-endif
+
+TESTS = fast-tests
+TESTS_ENVIRONMENT = $(SHELL)
 
 noinst_HEADERS = \
 	win32_unicode_support.h \

--- a/cli/all-tests
+++ b/cli/all-tests
@@ -1,0 +1,2 @@
+set -e
+./wvtest --default

--- a/cli/fast-tests
+++ b/cli/fast-tests
@@ -1,0 +1,2 @@
+set -e
+./wvtest --exhaustive --short --no-extras

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ AC_ARG_ENABLE([legacy],
 AS_IF([test "x$enable_legacy" = "xyes"],
     [AC_DEFINE([ENABLE_LEGACY])])
 
-AM_CONDITIONAL([ENABLE_LEGACY], [test "x$enable_legacy" == "xyes"])
+AM_CONDITIONAL([ENABLE_LEGACY], [test "x$enable_legacy" = "xyes"])
 
 AC_ARG_ENABLE([dsd],
     AS_HELP_STRING([--disable-dsd], [disable support for WavPack DSD files]))
@@ -146,12 +146,12 @@ AM_CONDITIONAL([ENABLE_DSD], [test "x$enable_dsd" != "xno"])
 AC_ARG_ENABLE([rpath],
     AS_HELP_STRING([--enable-rpath], [hardcode library path in executables]))
 
-AM_CONDITIONAL([ENABLE_RPATH], [test "x$enable_rpath" == "xyes"])
+AM_CONDITIONAL([ENABLE_RPATH], [test "x$enable_rpath" = "xyes"])
 
 AC_ARG_ENABLE([tests],
     AS_HELP_STRING([--enable-tests], [build libwavpack test program (requires Pthreads)]))
 
-AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" == "xyes"])
+AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = "xyes"])
 
 AC_ARG_ENABLE([asm],
     [AS_HELP_STRING([--disable-asm], [disable assembly optimizations])],,

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_INIT(wavpack, 5.4.0, bryant@wavpack.com)
 AC_CONFIG_SRCDIR([src/pack.c])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([serial-tests])
 AM_MAINTAINER_MODE
 
 LIBWAVPACK_MAJOR=5
@@ -148,11 +148,6 @@ AC_ARG_ENABLE([rpath],
 
 AM_CONDITIONAL([ENABLE_RPATH], [test "x$enable_rpath" = "xyes"])
 
-AC_ARG_ENABLE([tests],
-    AS_HELP_STRING([--enable-tests], [build libwavpack test program (requires Pthreads)]))
-
-AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = "xyes"])
-
 AC_ARG_ENABLE([asm],
     [AS_HELP_STRING([--disable-asm], [disable assembly optimizations])],,
     [enable_asm=check])
@@ -216,6 +211,10 @@ fi
 
 AM_CONDITIONAL(ENABLE_MAN, test x$enable_man != xno)
 
+AC_CONFIG_LINKS([
+  cli/all-tests:cli/all-tests
+  cli/fast-tests:cli/fast-tests
+])
 AC_CONFIG_FILES(
 Makefile
 wavpack.pc

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,11 +1,13 @@
-man_MANS = wavpack.1 wvgain.1 wvunpack.1 wvtag.1
+dist_man_MANS = wavpack.1 wvgain.1 wvunpack.1 wvtag.1
 
 if ENABLE_MAN
-%.1: %.xml
+.xml.1:
 	$(XSLTPROC) -nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
+
+SUFFIXES = .1 .xml
 endif
 
-EXTRA_DIST = $(man_MANS) $(patsubst %.1,%.xml,$(man_MANS))
+EXTRA_DIST = wavpack.xml wvgain.xml wvunpack.xml wvtag.xml
 
 MAINTAINERCLEANFILES = \
 	$(man_MANS) \


### PR DESCRIPTION
Hi @dbry 
Here are a few updates to make the Autotools build system POSIX compatible so it can be used with shell like Dash and Make implementations such as `bmake` and `pmake`. Furthermore, I've implemented the test to use the normal automake test harness, which means it can be invoked with `make check` instead of invoking the binary directly. This massively simplifies the packaging for us downstream in the distributions.