### PR TITLE
eliminate use of '&' address-of operator on arrays:

### DIFF
--- a/src/extra1.c
+++ b/src/extra1.c
@@ -234,7 +234,7 @@ static void recurse_mono (WavpackContext *wpc, WavpackExtraInfo *info, int depth
     if (branches < 1 || depth + 1 == info->nterms)
         branches = 1;
 
-    CLEAR (term_bits);
+    CLEARA (term_bits);
     samples = info->sampleptrs [depth];
     outsamples = info->sampleptrs [depth + 1];
 
@@ -553,7 +553,7 @@ void execute_mono (WavpackContext *wpc, int32_t *samples, int no_history, int do
     log_limit = 0;
 #endif
 
-    CLEAR (save_decorr_passes);
+    CLEARA (save_decorr_passes);
     temp_buffer [0] = malloc (buf_size);
     temp_buffer [1] = malloc (buf_size);
     best_buffer = malloc (buf_size);
@@ -608,7 +608,7 @@ void execute_mono (WavpackContext *wpc, int32_t *samples, int no_history, int do
 
         while (1) {
         memcpy (temp_buffer [0], noisy_buffer ? noisy_buffer : samples, buf_size);
-        CLEAR (save_decorr_passes);
+        CLEARA (save_decorr_passes);
 
         for (j = 0; j < nterms; ++j) {
             CLEAR (temp_decorr_pass);

--- a/src/extra2.c
+++ b/src/extra2.c
@@ -393,7 +393,7 @@ static void recurse_stereo (WavpackContext *wpc, WavpackExtraInfo *info, int dep
     if (branches < 1 || depth + 1 == info->nterms)
         branches = 1;
 
-    CLEAR (term_bits);
+    CLEARA (term_bits);
     samples = info->sampleptrs [depth];
     outsamples = info->sampleptrs [depth + 1];
 
@@ -647,7 +647,8 @@ static void stereo_add_noise (WavpackStream *wps, int32_t *lptr, int32_t *rptr)
 
     scan_word (wps, rptr, wps->wphdr.block_samples, -1);
     cnt = wps->wphdr.block_samples;
-    CLEAR (error);
+    error [0] = 0;
+    error [1] = 0;
 
     if (wps->wphdr.flags & HYBRID_SHAPE) {
         while (cnt--) {
@@ -743,7 +744,7 @@ void execute_stereo (WavpackContext *wpc, int32_t *samples, int no_history, int 
             force_ts = 1;
     }
 
-    CLEAR (save_decorr_passes);
+    CLEARA (save_decorr_passes);
     temp_buffer [0] = malloc (buf_size);
     temp_buffer [1] = malloc (buf_size);
     best_buffer = malloc (buf_size);
@@ -815,7 +816,7 @@ void execute_stereo (WavpackContext *wpc, int32_t *samples, int no_history, int 
             else
                 memcpy (temp_buffer [0], noisy_buffer ? noisy_buffer : samples, buf_size);
 
-            CLEAR (save_decorr_passes);
+            CLEARA (save_decorr_passes);
 
             for (j = 0; j < nterms; ++j) {
                 CLEAR (temp_decorr_pass);

--- a/src/tag_utils.c
+++ b/src/tag_utils.c
@@ -523,7 +523,7 @@ static int write_tag_reader (WavpackContext *wpc)
 
     if (result && tag_size < -m_tag->tag_file_pos && !wpc->reader->truncate_here) {
         int nullcnt = (int) (-m_tag->tag_file_pos - tag_size);
-        char zero [1] = { 0 };
+        char zero = 0;
 
         while (nullcnt--)
             wpc->reader->write_bytes (wpc->wv_in, &zero, 1);

--- a/src/wavpack_local.h
+++ b/src/wavpack_local.h
@@ -317,6 +317,7 @@ struct WavpackContext {
 //////////////////////// function prototypes and macros //////////////////////
 
 #define CLEAR(destin) memset (&destin, 0, sizeof (destin));
+#define CLEARA(destin) memset (destin, 0, sizeof (destin)); /* for arrays */
 
 //////////////////////////////// decorrelation //////////////////////////////
 // modules: pack.c, unpack.c, unpack_floats.c, extra1.c, extra2.c


### PR DESCRIPTION
fixes warnings from WatcomC (Open Watcom):
```
extra1.c(237): Warning! W115: &array may not produce intended result
extra1.c(556): Warning! W115: &array may not produce intended result
extra1.c(611): Warning! W115: &array may not produce intended result
extra2.c(396): Warning! W115: &array may not produce intended result
extra2.c(650): Warning! W115: &array may not produce intended result
extra2.c(746): Warning! W115: &array may not produce intended result
extra2.c(818): Warning! W115: &array may not produce intended result
tag_utils.c(529): Warning! W115: &array may not produce intended result
```
