### PR TITLE
mark x86 asm functions as __cdecl for Watcom compiler :

### DIFF
--- a/src/extra1.c
+++ b/src/extra1.c
@@ -43,7 +43,7 @@
 #endif
 
 #ifdef PACK_DECORR_MONO_PASS_CONT
-    void PACK_DECORR_MONO_PASS_CONT (int32_t *out_buffer, int32_t *in_buffer,  struct decorr_pass *dpp, int32_t sample_count);
+    void ASMCALL PACK_DECORR_MONO_PASS_CONT (int32_t *out_buffer, int32_t *in_buffer,  struct decorr_pass *dpp, int32_t sample_count);
 #endif
 
 typedef struct {

--- a/src/extra2.c
+++ b/src/extra2.c
@@ -50,8 +50,8 @@
 #endif
 
 #ifdef PACK_DECORR_STEREO_PASS_CONT
-    void PACK_DECORR_STEREO_PASS_CONT (struct decorr_pass *dpp, int32_t *in_buffer, int32_t *out_buffer, int32_t sample_count);
-    void PACK_DECORR_STEREO_PASS_CONT_REV (struct decorr_pass *dpp, int32_t *in_buffer, int32_t *out_buffer, int32_t sample_count);
+    void ASMCALL PACK_DECORR_STEREO_PASS_CONT (struct decorr_pass *dpp, int32_t *in_buffer, int32_t *out_buffer, int32_t sample_count);
+    void ASMCALL PACK_DECORR_STEREO_PASS_CONT_REV (struct decorr_pass *dpp, int32_t *in_buffer, int32_t *out_buffer, int32_t sample_count);
 #endif
 
 typedef struct {

--- a/src/pack.c
+++ b/src/pack.c
@@ -973,13 +973,13 @@ void send_general_metadata (WavpackContext *wpc)
     #define SCAN_MAX_MAGNITUDE scan_max_magnitude
 #endif
 
-uint32_t DECORR_MONO_BUFFER (int32_t *buffer, struct decorr_pass *decorr_passes, int32_t num_terms, int32_t sample_count);
+uint32_t ASMCALL DECORR_MONO_BUFFER (int32_t *buffer, struct decorr_pass *decorr_passes, int32_t num_terms, int32_t sample_count);
 
 #ifdef OPT_ASM_X86
 void decorr_stereo_pass (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count);
-void pack_decorr_stereo_pass_x86 (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count);
+void ASMCALL pack_decorr_stereo_pass_x86 (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count);
 uint32_t scan_max_magnitude (int32_t *values, int32_t num_values);
-uint32_t scan_max_magnitude_x86 (int32_t *values, int32_t num_values);
+uint32_t ASMCALL scan_max_magnitude_x86 (int32_t *values, int32_t num_values);
 #else
 void DECORR_STEREO_PASS (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count);
 uint32_t SCAN_MAX_MAGNITUDE (int32_t *values, int32_t num_values);

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -37,8 +37,8 @@
 #endif
 
 #ifdef DECORR_STEREO_PASS_CONT
-extern void DECORR_STEREO_PASS_CONT (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count, int32_t long_math);
-extern void DECORR_MONO_PASS_CONT (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count, int32_t long_math);
+extern void ASMCALL DECORR_STEREO_PASS_CONT (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count, int32_t long_math);
+extern void ASMCALL DECORR_MONO_PASS_CONT (struct decorr_pass *dpp, int32_t *buffer, int32_t sample_count, int32_t long_math);
 #endif
 
 // This flag provides the functionality of terminating the decoding and muting

--- a/src/wavpack_local.h
+++ b/src/wavpack_local.h
@@ -20,6 +20,12 @@
 #define FASTCALL
 #endif
 
+#if defined(__WATCOMC__) && defined(OPT_ASM_X86)
+#define ASMCALL __cdecl
+#else
+#define ASMCALL
+#endif
+
 #if defined(_WIN32) || \
     (defined(BYTE_ORDER) && defined(LITTLE_ENDIAN) && (BYTE_ORDER == LITTLE_ENDIAN)) || \
     (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
@@ -405,7 +411,8 @@ void decimate_dsd_destroy (void *decimate_context);
 
 ///////////////////////////////// CPU feature detection ////////////////////////////////
 
-int unpack_cpu_has_feature_x86 (int findex), pack_cpu_has_feature_x86 (int findex);
+int ASMCALL unpack_cpu_has_feature_x86 (int findex);
+int ASMCALL pack_cpu_has_feature_x86 (int findex);
 
 #define CPU_FEATURE_MMX     23
 
@@ -559,7 +566,7 @@ int FASTCALL wp_log2 (uint32_t avalue);
 #define LOG2BUFFER log2buffer
 #endif
 
-uint32_t LOG2BUFFER (int32_t *samples, uint32_t num_samples, int limit);
+uint32_t ASMCALL LOG2BUFFER (int32_t *samples, uint32_t num_samples, int limit);
 
 signed char store_weight (int weight);
 int restore_weight (signed char weight);


### PR DESCRIPTION
`__cdecl` isn't default calling convention for Watcom.  This handles calling convention and also symbol decoration correctly.