### PR TITLE
miscellaneous build / warning fixes:

### DIFF
--- a/cli/aiff.c
+++ b/cli/aiff.c
@@ -162,7 +162,7 @@ int ParseAiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
                         int pstring_len = (unsigned char) common_chunk.compressionName [0];
 
                         if (pstring_len >= 1 && pstring_len <= chunk_header.ckSize - 23) {
-                            char compressionName [pstring_len + 1];
+                            char compressionName [256];
                             int i, j;
 
                             for (j = i = 0; i < pstring_len; ++i)

--- a/cli/aiff.c
+++ b/cli/aiff.c
@@ -242,6 +242,9 @@ int ParseAiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
             }
         }
         else if (!strncmp (chunk_header.ckID, "SSND", 4)) {             // on the data chunk, get size and exit loop
+            int64_t data_chunk_size;
+            int bytes_per_frame;
+
             if (!common_chunks || chunk_header.ckSize < sizeof (sound_chunk)      ||
                 (!version_chunks && aiff_chunk_header.formType [3] == 'C')        ||
                 !DoReadFile (infile, &sound_chunk, sizeof (sound_chunk), &bcount) ||
@@ -262,8 +265,8 @@ int ParseAiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
                 return WAVPACK_SOFT_ERROR;
             }
 
-            int64_t data_chunk_size = chunk_header.ckSize - sizeof (sound_chunk);
-            int bytes_per_frame = config->bytes_per_sample * config->num_channels;
+            data_chunk_size = chunk_header.ckSize - sizeof (sound_chunk);
+            bytes_per_frame = config->bytes_per_sample * config->num_channels;
 
             if (infilesize && !(config->qmode & QMODE_IGNORE_LENGTH) && infilesize - data_chunk_size > 16777216) {
                 error_line ("this .AIF file has over 16 MB of extra AIF data, probably is corrupt!");

--- a/cli/utils.c
+++ b/cli/utils.c
@@ -687,7 +687,7 @@ int64_t DoGetFileSize (FILE *hFile)
     if (fHandle == INVALID_HANDLE_VALUE)
         return 0;
 
-    Size.u.LowPart = GetFileSize(fHandle, &Size.u.HighPart);
+    Size.u.LowPart = GetFileSize(fHandle, (DWORD *) &Size.u.HighPart);
 
     if (Size.u.LowPart == INVALID_FILE_SIZE && GetLastError() != NO_ERROR)
         return 0;

--- a/cli/utils.c
+++ b/cli/utils.c
@@ -12,6 +12,7 @@
 // utilities and the self-extraction module.
 
 #if defined(_WIN32)
+#define _WIN32_WINNT 0x0500 /* for GetConsoleWindow() */
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <io.h>

--- a/cli/wvparser.c
+++ b/cli/wvparser.c
@@ -152,7 +152,7 @@ int main (int argc, char **argv)
     }
 
 #ifdef _WIN32
-    setmode (fileno (stdin), O_BINARY);
+    setmode (_fileno (stdin), O_BINARY);
 #endif
     fprintf (stderr, "%s", sign_on);
 

--- a/cli/wvunpack.c
+++ b/cli/wvunpack.c
@@ -57,7 +57,6 @@
 #define fopen(f,m) fopen_utf8(f,m)
 #define strdup(x) _strdup(x)
 #define snprintf _snprintf
-#define fileno _fileno
 #endif
 
 ///////////////////////////// local variable storage //////////////////////////
@@ -1187,7 +1186,7 @@ static int quick_verify_file (char *infilename, int verbose)
     if (*infilename == '-') {
         infile = stdin;
 #ifdef _WIN32
-        _setmode (fileno (stdin), O_BINARY);
+        _setmode (_fileno (stdin), O_BINARY);
 #endif
 #ifdef __OS2__
         setmode (fileno (stdin), O_BINARY);

--- a/src/open_filename.c
+++ b/src/open_filename.c
@@ -118,7 +118,7 @@ static int64_t get_length (void *id)
     if (fHandle == INVALID_HANDLE_VALUE)
         return 0;
 
-    Size.u.LowPart = GetFileSize(fHandle, &Size.u.HighPart);
+    Size.u.LowPart = GetFileSize(fHandle, (DWORD *) &Size.u.HighPart);
 
     if (Size.u.LowPart == INVALID_FILE_SIZE && GetLastError() != NO_ERROR)
         return 0;

--- a/winamp/in_wv.c
+++ b/winamp/in_wv.c
@@ -18,8 +18,6 @@
 #include "resource.h"
 #include "wasabi/wasabi.h"
 
-#define fileno _fileno
-
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
@@ -1272,7 +1270,7 @@ static int can_seek (void *id)
     FILE *file = id ? *(FILE**)id : NULL;
     struct stat statbuf;
 
-    return file && !fstat (fileno (file), &statbuf) && S_ISREG(statbuf.st_mode);
+    return file && !fstat (_fileno (file), &statbuf) && S_ISREG(statbuf.st_mode);
 }
 
 static int32_t write_bytes (void *id, void *data, int32_t bcount)
@@ -1290,7 +1288,7 @@ static int truncate_here (void *id)
     FILE *file = id ? *(FILE**)id : NULL;
     int64_t curr_pos = _ftelli64 (file);
 
-    return _chsize_s (fileno (file), curr_pos);
+    return _chsize_s (_fileno (file), curr_pos);
 }
 
 static WavpackStreamReader64 freader = {


### PR DESCRIPTION
- cli/aiff.c: eliminate declaration-after-statement for c89 compilers
- cli/aiff.c: lose c99 vla and use a fixed [256] array for `compressionName`
- silence incompatible pointer warning for `GetFileSize()`.
- cli/utils.c: define `_WIN32_WINNT` as `0x0500` for `GetConsoleWindow()`.
- win32: don't define `fileno` as `_fileno` to avoid possible errors/warnings
