### PR TITLE
enable clz and ctz optimizations for watcom builds.

### DIFF
--- a/src/read_words.c
+++ b/src/read_words.c
@@ -31,6 +31,14 @@
 
 #if defined (HAVE___BUILTIN_CTZ) || defined (_WIN64)
 #define USE_CTZ_OPTIMIZATION    // use ctz intrinsic (or Windows equivalent) to count trailing ones
+#elif defined(__WATCOMC__) && defined(__386__)
+#define USE_CTZ_OPTIMIZATION
+extern __inline uint32_t _bsf_watcom (uint32_t);
+#pragma aux _bsf_watcom = \
+  "bsf eax, eax" \
+  parm [eax] nomemory \
+  value [eax] \
+  modify exact [eax] nomemory;
 #else
 #define USE_NEXT8_OPTIMIZATION  // optimization using a table to count trailing ones
 #endif
@@ -126,6 +134,8 @@ int32_t FASTCALL get_word (WavpackStream *wps, int chan, int32_t *correction)
 
 #ifdef _MSC_VER
         { unsigned long res; _BitScanForward (&res, (unsigned long)~wps->wvbits.sr); ones_count = (uint32_t) res; }
+#elif defined(__WATCOMC__) && defined(__386__)
+        ones_count = _bsf_watcom (~wps->wvbits.sr);
 #else
         ones_count = __builtin_ctz (~wps->wvbits.sr);
 #endif
@@ -405,6 +415,8 @@ int32_t get_words_lossless (WavpackStream *wps, int32_t *buffer, int32_t nsample
 
 #ifdef _MSC_VER
         { unsigned long res; _BitScanForward (&res, (unsigned long)~wps->wvbits.sr); ones_count = (uint32_t) res; }
+#elif defined(__WATCOMC__) && defined(__386__)
+        ones_count = _bsf_watcom (~wps->wvbits.sr);
 #else
         ones_count = __builtin_ctz (~wps->wvbits.sr);
 #endif

--- a/src/wavpack_local.h
+++ b/src/wavpack_local.h
@@ -528,6 +528,14 @@ uint32_t bs_close_read (Bitstream *bs);
 
 #ifdef HAVE___BUILTIN_CLZ
 #define count_bits(av) ((av) ? 32 - __builtin_clz (av) : 0)
+#elif defined (__WATCOMC__) && defined(__386__)
+extern __inline int _bsr_watcom(uint32_t);
+#pragma aux _bsr_watcom = \
+  "bsr eax, eax" \
+  parm [eax] nomemory \
+  value [eax] \
+  modify exact [eax] nomemory;
+#define count_bits(av) ((av) ? _bsr_watcom((av)) + 1 : 0)
 #elif defined (_WIN64)
 static __inline int count_bits (uint32_t av) { unsigned long res; return _BitScanReverse (&res, av) ? (int)(res + 1) : 0; }
 #else


### PR DESCRIPTION
Uses `bsr` and `bsf` inline asm in watcom aux pragma syntax.

Question: these optimizations are not enabled in MSVC 32 bit
builds: is there a reason?
