### PR TITLE
cmake: fixes to winamp plugin build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,17 +523,21 @@ if(WAVPACK_BUILD_WINAMP_PLUGIN)
         winamp/wasabi/wasabi.h
     )
     target_compile_definitions(in_wv PRIVATE $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_DEPRECATE>)
-    set_target_properties(in_wv PROPERTIES DEFINE_SYMBOL WINAMP_EXPORTS)
+    set_target_properties(in_wv PROPERTIES
+        DEFINE_SYMBOL WINAMP_EXPORTS
+        PREFIX ""
+    )
     target_link_libraries(in_wv PRIVATE wavpack)
 
-    add_library(in_wv_lang SHARED
+    add_library(in_wv_lng SHARED
         winamp/wavpack.rc
     )
-    target_link_libraries(in_wv_lang PRIVATE $<$<BOOL:${MSVC}>:-NOENTRY>)
-    set_target_properties(in_wv_lang PROPERTIES
+    target_link_libraries(in_wv_lng PRIVATE $<$<BOOL:${MSVC}>:-NOENTRY>)
+    set_target_properties(in_wv_lng PROPERTIES
         RUNTIME_OUTPUT_NAME in_wv
         PREFIX ""
-        SUFFIX ".lang"
+        SUFFIX ".lng"
+        LINKER_LANGUAGE "C"
     )
 
 endif()
@@ -585,7 +589,7 @@ set_package_properties(Threads PROPERTIES
 )
 set_package_properties(LibXslt PROPERTIES
 	TYPE OPTIONAL
-	DESCRIPTION " XSLT C library developed for the GNOME project."
+	DESCRIPTION "XSLT C library developed for the GNOME project."
     PURPOSE "Required to generate documentation."
 )
 
@@ -682,7 +686,7 @@ endif()
 
 if(BUILD_TESTING AND (NOT WIN32))
 
-	enable_testing()
+    enable_testing()
 
     add_executable(wvtest
         cli/wvtest.c

--- a/winamp/in_wv.c
+++ b/winamp/in_wv.c
@@ -801,7 +801,6 @@ DWORD WINAPI __stdcall DecodeThread (void *b)
 
         if (seek_needed != -1) {
             int seek_position = seek_needed;
-            int bc = 0;
 
             seek_needed = -1;
 


### PR DESCRIPTION
- the plugin dll must be named 'in_wv.dll' without 'lib' prefix.
- the 'lng' file is now built (was missing the 'LINKER_LANGUAGE' property), and is correctly named (*.lng, not *.lang) matching the MSVC project file.