### PR TITLE
CMake + MSVC fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,7 +543,7 @@ if(WAVPACK_BUILD_WINAMP_PLUGIN)
     )
     target_link_libraries(in_wv_lng PRIVATE $<$<BOOL:${MSVC}>:-NOENTRY>)
     set_target_properties(in_wv_lng PROPERTIES
-        RUNTIME_OUTPUT_NAME in_wv
+        OUTPUT_NAME in_wv
         PREFIX ""
         SUFFIX ".lng"
         LINKER_LANGUAGE "C"

--- a/wavpackdll/wavpackdll.rc
+++ b/wavpackdll/wavpackdll.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winresrc.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include <winresrc.rc>\r\n"
     "\0"
 END
 

--- a/wavpackdll/wavpackdll.vcxproj
+++ b/wavpackdll/wavpackdll.vcxproj
@@ -183,6 +183,7 @@
 /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
 /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
 /export:WavpackVerifySingleBlock
+/export:WavpackFloatNormalize
  %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)wavpackdll.dll</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -240,6 +241,7 @@
 /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
 /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
 /export:WavpackVerifySingleBlock
+/export:WavpackFloatNormalize
  %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)wavpackdll.dll</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -302,6 +304,7 @@
 /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
 /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
 /export:WavpackVerifySingleBlock
+/export:WavpackFloatNormalize
  %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)wavpackdll.dll</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>


### PR DESCRIPTION
- Some MSVC configurations did not export `WavpackFloatNormalize`.
- In my last pr, I converted the library types to MODULE. Looks like one needs to set the `OUTPUT_NAME` property on them.
- I don't have MFC installed on my system, so I changed `#include <windows.h>` to `#include <windows.h>`.
  Everything keeps building. But I'm no expert in MFC stuff.

With these changes, running `dumpbin /exports` on the dll's, lng's or flt's give me no difference in exported symbols.