### PR TITLE
CMake fixes for WinAMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,7 +536,7 @@ if(WAVPACK_BUILD_WINAMP_PLUGIN)
         PREFIX ""
     )
     if(MINGW)
-        target_link_libraries(in_wv PRIVATE -mwindows)
+        target_link_libraries(in_wv PRIVATE -mwindows -static-libgcc -static-libstdc++)
     endif()
 
     add_library(in_wv_lng MODULE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,13 +527,14 @@ if(WAVPACK_BUILD_WINAMP_PLUGIN)
         winamp/resource.h
         winamp/wasabi/wasabi.cpp
         winamp/wasabi/wasabi.h
+        $<TARGET_OBJECTS:wavpack>
     )
+    target_include_directories(in_wv PRIVATE include)
     target_compile_definitions(in_wv PRIVATE $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_DEPRECATE>)
     set_target_properties(in_wv PROPERTIES
         DEFINE_SYMBOL WINAMP_EXPORTS
         PREFIX ""
     )
-    target_link_libraries(in_wv PRIVATE wavpack)
     if(MINGW)
         target_link_libraries(in_wv PRIVATE -mwindows)
     endif()


### PR DESCRIPTION
With these fixes, I am able to let the WavPack Decoder plug-in appear in WinAMP.
Proof:
![image](https://user-images.githubusercontent.com/4138939/202829425-2db943aa-9811-43b6-a978-a84c442c5e22.png)

- By adding the objects of wavpack to `in_wv.dll` instead of linking to it, you don't need to copy the `wavpackdll.dll` to the winamp folder. Copying `wavpackdll.dll` to the `Plugins` folder wasn't enough, you had to copy it to the folder containing the winamp executable. By embedding wavpack in `in_wv.dll`, there are no more external dependencies.
- Link to static libgcc and libstdc++ to avoid needing the GNU standard library in a public location.

I suppose cooledit suffers from similar issues.