### PR TITLE
misc patches to plugins:

### DIFF
--- a/audition/Makefile.wat
+++ b/audition/Makefile.wat
@@ -1,0 +1,82 @@
+# OpenWatcom makefile to build CoolEdit plugin 'cool_wv4.flt' for Win32
+
+LIBNAME = cool_wv4
+
+DLLFILE = $(LIBNAME).flt
+LNKFILE = $(LIBNAME).lnk
+
+CC = wcc386
+RC = wrc
+
+WAVPACK_LIB = wavpack.lib
+
+CFLAGS = -bt=nt -d0 -zq -bm -5s -fp5 -fpi87 -sg -oeatxh -ei
+#CFLAGS+= -j
+# warnings:
+CFLAGS+= -wx
+# newer OpenWatcom versions enable W303 by default:
+CFLAGS+= -wcd=303
+# include paths:
+CFLAGS+= -I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
+CFLAGS+= -I"../include"
+# to build a dll:
+CFLAGS+= -bd
+RCFLAGS = -q -r -bt=nt -I"$(%WATCOM)/h/nt"
+
+SRCS = cool_wv4.c
+RCSRCS = wavpack.rc
+
+.extensions:
+.extensions: .lib .flt .obj .res .c .rc
+
+OBJS = $(SRCS:.c=.obj)
+RCOBJS= $(RCSRCS:.rc=.res)
+
+all: $(DLLFILE)
+
+$(DLLFILE): $(OBJS) $(RCOBJS) $(LNKFILE)
+  @echo * Link: $@
+  wlink @$(LNKFILE)
+
+$(LNKFILE):
+  @%create $@
+  @%append $@ SYSTEM nt_dll INITINSTANCE TERMINSTANCE
+  @%append $@ NAME $(DLLFILE)
+  @for %i in ($(OBJS)) do @%append $@ FILE %i
+  @%append $@ OPTION QUIET
+  @%append $@ OPTION RESOURCE=$(RCOBJS)
+  @%append $@ LIB $(WAVPACK_LIB)
+  @%append $@ export 'QueryCoolFilter'='_QueryCoolFilter@4'
+  @%append $@ export 'FilterUnderstandsFormat'='_FilterUnderstandsFormat@4'
+  @%append $@ export 'GetSuggestedSampleType'='_GetSuggestedSampleType@12'
+  @%append $@ export 'OpenFilterInput'='_OpenFilterInput@24'
+  @%append $@ export 'FilterGetFileSize'='_FilterGetFileSize@4'
+  @%append $@ export 'ReadFilterInput'='_ReadFilterInput@12'
+  @%append $@ export 'CloseFilterInput'='_CloseFilterInput@4'
+  @%append $@ export 'FilterOptions'='_FilterOptions@4'
+  @%append $@ export 'FilterOptionsString'='_FilterOptionsString@8'
+  @%append $@ export 'OpenFilterOutput'='_OpenFilterOutput@28'
+  @%append $@ export 'CloseFilterOutput'='_CloseFilterOutput@4'
+  @%append $@ export 'WriteFilterOutput'='_WriteFilterOutput@12'
+  @%append $@ export 'FilterGetOptions'='_FilterGetOptions@24'
+  @%append $@ export 'FilterWriteSpecialData'='_FilterWriteSpecialData@20'
+  @%append $@ export 'FilterGetFirstSpecialData'='_FilterGetFirstSpecialData@8'
+  @%append $@ export 'FilterGetNextSpecialData'='_FilterGetNextSpecialData@8'
+  @%append $@ OPTION MAP=$*
+  @%append $@ OPTION ELIMINATE
+  @%append $@ OPTION SHOWDEAD
+
+.c.obj:
+  $(CC) $(CFLAGS) -Fo=$^@ $<
+.rc.res:
+  $(RC) $(RCFLAGS) -Fo=$^@ $<
+
+clean: .SYMBOLIC
+  @if exist *.obj rm *.obj
+  @if exist *.res rm *.res
+  @if exist *.err rm *.err
+  @if exist $(LNKFILE) rm $(LNKFILE)
+
+distclean: .SYMBOLIC clean
+  @if exist $(DLLFILE) rm $(DLLFILE)
+  @if exist *.map rm *.map

--- a/winamp/in_wv.c
+++ b/winamp/in_wv.c
@@ -1288,9 +1288,17 @@ static int32_t write_bytes (void *id, void *data, int32_t bcount)
 static int truncate_here (void *id)
 {
     FILE *file = id ? *(FILE**)id : NULL;
-    int64_t curr_pos = _ftelli64 (file);
 
-    return _chsize_s (_fileno (file), curr_pos);
+    if (file) {
+        #ifdef __WATCOMC__ /*  no _chsize_s() in watcom... */
+        HANDLE handle = (HANDLE) _get_osfhandle (_fileno (file));
+        return (SetEndOfFile(handle) != 0) ? 0 : -1;
+        #else
+        int64_t curr_pos = _ftelli64 (file);
+        return _chsize_s (_fileno (file), curr_pos);
+        #endif
+    }
+    return 0;
 }
 
 static WavpackStreamReader64 freader = {

--- a/winamp/wasabi/Winamp/wa_ipc.h
+++ b/winamp/wasabi/Winamp/wa_ipc.h
@@ -1406,11 +1406,11 @@ class IVideoOutput
     virtual void setcallback(LRESULT (*msgcallback)(void *token, HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam), void *token) { (void)token; (void)msgcallback; /* to eliminate warning C4100 */ }
     virtual void close()=0;
     virtual void draw(void *frame)=0;
-    virtual void drawSubtitle(SubsItem *item) {UNREFERENCED_PARAMETER(item);  }
-    virtual void showStatusMsg(const char *text) {UNREFERENCED_PARAMETER(text);  }
+    virtual void drawSubtitle(SubsItem *item) { (void)(item);  }
+    virtual void showStatusMsg(const char *text) { (void)(text);  }
     virtual int get_latency() { return 0; }
-    virtual void notifyBufferState(int bufferstate) { UNREFERENCED_PARAMETER(bufferstate); } /* 0-255*/
-	virtual INT_PTR extended(INT_PTR param1, INT_PTR param2, INT_PTR param3) { UNREFERENCED_PARAMETER(param1); UNREFERENCED_PARAMETER(param2); UNREFERENCED_PARAMETER(param3); return 0; } // Dispatchable, eat this!
+    virtual void notifyBufferState(int bufferstate) { (void)(bufferstate); } /* 0-255*/
+	virtual INT_PTR extended(INT_PTR param1, INT_PTR param2, INT_PTR param3) { (void)(param1); (void)(param2); (void)(param3); return 0; } // Dispatchable, eat this!
 };
 
 class ITrackSelector 


### PR DESCRIPTION
- add OpenWatcom makefile to build Win32 CoolEdit plugin.
- use prototyped function ptrs instead of an opaque FARPROC
  (same as https://github.com/dbry/WavPack/pull/140, but for winamp plugin.)
- winamp/wa_ipc.h: replace UNREFERENCED_PARAMETER(item) with (void)(item)
  win32 sdk defines `UNREFERENCED_PARAMETER(item)` as `(item)` which generates
  warnings with other compilers.
- winamp plugin, truncate_here(): watcom clib support

Not adding a watcom makefile for winamp plugin because the result is reported
to crash in ticket #146.

(Question: One curious thing in winamp plugin is that its reader passes pointers to `FILE*`
pointers instead just just the `FILE*` pointers themselves. Any specific reason??)
