### PR TITLE
Manpages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,11 +584,6 @@ set_package_properties(Threads PROPERTIES
 	DESCRIPTION "Threads library"
     PURPOSE "Required to build tests."
 )
-set_package_properties(LibXslt PROPERTIES
-	TYPE OPTIONAL
-	DESCRIPTION "XSLT C library developed for the GNOME project."
-    PURPOSE "Required to generate documentation."
-)
 
 add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "Build shared library.")
 add_feature_info(BUILD_TESTING BUILD_TESTING "Build tests.")

--- a/man/wavpack.1
+++ b/man/wavpack.1
@@ -30,15 +30,16 @@ and in that case
 may be used to specify an alternate target directory.
 A filename of
 .Dq -
-specifies the standard input and output.
+specifies
+.Pa stdin
+or
+.Pa stdout .
 .Pp
 When transcoding from existing WavPack files,
 all tags are copied, and may be modified with additional args;
 unless an alternate output file or directory is specified,
 the source files are safely overwritten.
-.Pp
-The following input formats are supported:
-.Pp
+.Ss INPUT FORMATS
 .Bl -bullet -compact
 .It
 Microsoft RIFF, extension
@@ -64,8 +65,7 @@ Philips DSDIFF, extension
 Sony DSD Stream, extension
 .Dq .dsf
 .El
-.Pp
-The options are as follows:
+.Ss OPTIONS
 .Bl -tag -width Ds
 .It Fl a
 Adobe Audition (CoolEdit) mode for 32-bit floats
@@ -73,7 +73,7 @@ Adobe Audition (CoolEdit) mode for 32-bit floats
 Allow tag data up to 16 MB.
 Embedding > 1 MB is not recommended for portable devices
 and may not work with some programs, including older WavPack versions.
-.It Fl b Ar n
+.It Fl b Ns Ar n
 enable hybrid compression,
 .Ar n
 = 2.0 to 23.9 bits/sample, or
@@ -103,7 +103,8 @@ On by default in lossless mode and with the
 .Fl cc
 option.
 .It Fl d
-Delete source file if successful.
+delete source file if successful;
+.Sy use with caution!
 .It Fl f
 fast mode; introduces a compromise in compression ratio
 .It Fl -force-even-byte-depth
@@ -208,7 +209,7 @@ write program version to
 .Pa stdout
 .It Fl w Encoder
 write encoder metadata to APEv2 tag (e.g.,
-.Dq Encoder=WavPack 5.5.0 )
+.Dq Encoder=WavPack 5.6.0 )
 .It Fl w Settings
 write user settings metadata to APEv2 tag (e.g.,
 .Dq Settings=-hb384cx3 )
@@ -220,7 +221,7 @@ normally used for embedded cuesheets and logs
 (field names
 .Dq Cuesheet
 and
-.Dq Log ).
+.Dq Log ) .
 .It Fl -write-binary-tag Do Ar Field Ns =@ Ns Ar file.ext Dc
 Write the specified binary metadata file to APEv2 tag;
 normally used for cover art with the field name
@@ -231,7 +232,8 @@ extra encode processing, n = 0 to 6, default=1;
 -x1 to -x3 to choose best of predefined filters,
 -x4 to -x6 to generate custom filters (very slow!)
 .It Fl y
-yes to all warnings (use with caution!)
+yes to all warnings;
+.Sy use with caution!
 .It Fl z[ Ns Ar n ]
 don't set (n=0 or omitted) or set (n=1) console title
 to indicate progress (leaves "WavPack Completed")

--- a/man/wvgain.1
+++ b/man/wvgain.1
@@ -17,8 +17,7 @@ ReplayGain-enabled players will use this information
 to produce the same perceived loudness on all tracks.
 Both individual track and whole album ReplayGain information
 can be calculated.
-.Pp
-The options are as follows:
+.Ss OPTIONS
 .Bl -tag -width Ds
 .It Fl a
 album mode (all files scanned are considered an album)

--- a/man/wvtag.1
+++ b/man/wvtag.1
@@ -6,7 +6,7 @@
 .Nd manipulate wavpack metadata
 .Sh SYNOPSIS
 .Nm wvtag
-.Op Fl cdhlqvwxy
+.Op Fl options
 .Ar
 .Sh DESCRIPTION
 .Nm
@@ -19,8 +19,7 @@ will automatically import from an ID3v1 tag
 if it is the only tag present in the source file,
 and that ID3v1 tag will be deleted and replaced with an APEv2 tag
 if an edit is requested.
-.Pp
-The options are as follows:
+.Ss OPTIONS
 .Bl -tag -width Ds
 .It Fl -allow-huge-tags
 allow tag data up to 16 MB.
@@ -98,7 +97,8 @@ which gets replaced with the extension of the binary tag source file
 .Dq txt
 for a text tag).
 .It Fl y
-yes to all warnings (use with caution!)
+yes to all warnings;
+.Sy use with caution!
 .El
 .Sh SEE ALSO
 .Xr wavpack 1 ,

--- a/man/wvunpack.1
+++ b/man/wvunpack.1
@@ -174,18 +174,18 @@ about WavPack file to
 .Pa stdout
 .It Fl -skip=[-][ Ns Ar sample Ns | Ns Ar hh : Ns Ar mm : Ns Ar ss.ss ]
 start decoding at specified sample or time index, specifying a
-.Sy -
+.Sq -
 causes sample/time to be relative to EOF
 .It Fl t
 copy input file's time stamp to output file(s)
 .It Fl -until=[+|-][ Ns Ar sample Ns | Ns Ar hh : Ns Ar mm : Ns Ar ss.ss ]
 stop decoding at specified sample or time index, specifying a
-.Sy +
+.Sq +
 causes sample/time to be relative to
 .Fl -skip
 point,
 specifying a
-.Sy -
+.Sq -
 causes sample/time to be relative to EOF
 .It Fl v
 verify source data only (no output file created)

--- a/man/wvunpack.1
+++ b/man/wvunpack.1
@@ -27,7 +27,10 @@ resulting in multiple output files, and in that case
 may be used to specify an alternate target directory.
 A filename of
 .Dq -
-specifies standard input and output.
+specifies
+.Pa stdin
+or
+.Pa stdout .
 It is also possible to export to one of the alternate file formats below,
 but in that case the information in the original headers and trailers
 will be lost, even if the alternate format is the same as the source format.
@@ -44,56 +47,54 @@ This can be utilized as an easy way to concatenate WavPack files
 but only makes sense with raw output
 .Pf ( Fl -raw )
 to avoid headers being interleaved with the audio data.
-.Pp
-The following output file formats are supported:
+.Ss OUTPUT FORMATS
 .Bl -bullet -compact
 .It
 Microsoft RIFF
-.Pq Dq wav ,
+.Pq Dq .wav ,
 force with
 .Fl -wav ,
 creates RF64 if > 4 GB
 .It
 Sony Wave64
-.Pq Dq w64 ,
+.Pq Dq .w64 ,
 force with
 .Fl -w64
 .It
 Apple AIFF
-.Pq Dq aif ,
+.Pq Dq .aif ,
 force with
 .Fl -aif
 or
 .Fl -aif-le
 .It
 Apple Core Audio
-.Pq Dq caf ,
+.Pq Dq .caf ,
 force with
 .Fl -caf-be
 or
 .Fl -caf-le
 .It
 Raw PCM or DSD
-.Pq Dq raw ,
+.Pq Dq .raw ,
 force with
 .Fl r
 or
 .Fl -raw
 .It
 Philips DSDIFF
-.Pq Dq dff ,
+.Pq Dq .dff ,
 force with
 .Fl -dsdiff
 or
 .Fl -dff
 .It
 Sony DSD Stream
-.Pq Dq dsf ,
+.Pq Dq .dsf ,
 force with
 .Fl -dsf
 .El
-.Pp
-The options are as follows:
+.Ss OPTIONS
 .Bl -tag -width Ds
 .It Fl -aif , Fl -aif-le
 force output to Apple AIFF (or AIFF-C/sowt), extension
@@ -117,7 +118,8 @@ file in same directory as decoded audio file
 force output to big-endian or little-endian Core Audio, extension
 .Dq .caf
 .It Fl d
-delete source file if successful (use with caution!)
+delete source file if successful;
+.Sy use with caution!
 .It Fl -dff , Fl -dsdiff
 force output to Philips DSDIFF, DSD audio source only, extension
 .Dq .dff
@@ -172,18 +174,18 @@ about WavPack file to
 .Pa stdout
 .It Fl -skip=[-][ Ns Ar sample Ns | Ns Ar hh : Ns Ar mm : Ns Ar ss.ss ]
 start decoding at specified sample or time index, specifying a
-.Fl
+.Sy -
 causes sample/time to be relative to EOF
 .It Fl t
 copy input file's time stamp to output file(s)
 .It Fl -until=[+|-][ Ns Ar sample Ns | Ns Ar hh : Ns Ar mm : Ns Ar ss.ss ]
 stop decoding at specified sample or time index, specifying a
-.Fl +
+.Sy +
 causes sample/time to be relative to
 .Fl -skip
 point,
 specifying a
-.Fl
+.Sy -
 causes sample/time to be relative to EOF
 .It Fl v
 verify source data only (no output file created)
@@ -213,7 +215,8 @@ replaced with the extension from the binary tag source file (or
 .Dq txt
 for text tag).
 .It Fl y
-yes to overwrite warning (use with caution!)
+yes to overwrite warning;
+.Sy use with caution!
 .It Fl z[ Ns Ar n ]
 don't set (n = 0 or omitted) or set (n = 1) console title
 to indicate progress (leaves "WvUnpack Completed")


### PR DESCRIPTION
@janstary , how about this?

Seems like the mdoc specs allow using `.Ss` to subdivide the `DESCRIPTION`, which I like (at least when there are lots of options). Checked with `mandoc -Tlint` and nothing new. Also your cmake change and several other minor tweaks.

Thanks! 