### PR TITLE
Silence gcc-9 -Wstringop-truncation warnings:

### DIFF
--- a/cli/wavpack.c
+++ b/cli/wavpack.c
@@ -347,7 +347,8 @@ int main (int argc, char **argv)
 #if defined(_WIN32)
     if (!GetModuleFileName (NULL, selfname, sizeof (selfname)))
 #endif
-    strncpy (selfname, *argv, sizeof (selfname));
+    strncpy (selfname, *argv, sizeof (selfname) - 1);
+    selfname [sizeof (selfname) - 1] = '\0';
 
     if (filespec_name (selfname)) {
         char *filename = filespec_name (selfname);

--- a/cli/wvunpack.c
+++ b/cli/wvunpack.c
@@ -285,7 +285,8 @@ int main(int argc, char **argv)
 #if defined(_WIN32)
     if (!GetModuleFileName (NULL, selfname, sizeof (selfname)))
 #endif
-    strncpy (selfname, *argv, sizeof (selfname));
+    strncpy (selfname, *argv, sizeof (selfname) - 1);
+    selfname [sizeof (selfname) - 1] = '\0';
 
     if (filespec_name (selfname)) {
         char *filename = filespec_name (selfname);


### PR DESCRIPTION
```
cli/wavpack.c: In function 'main':
cli/wavpack.c:350:5: warning: 'strncpy' specified bound 4096 equals destination size [-Wstringop-truncation]
  350 |     strncpy (selfname, *argv, sizeof (selfname));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cli/wvunpack.c: In function 'main':
cli/wvunpack.c:288:5: warning: 'strncpy' specified bound 4096 equals destination size [-Wstringop-truncation]
  288 |     strncpy (selfname, *argv, sizeof (selfname));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
