### PR TITLE
autotools, cmake: add -Wall to CFLAGS for gcc (or clang)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ if(LARGE_FILES_SUPPORTED)
 endif()
 check_function_exists(fseeko HAVE_FSEEKO)
 
+if(NOT MSVC AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang"))
+    add_compile_options(-Wall)
+endif()
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(CPU_ASM_X64 1)

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,10 @@ AS_IF([test "x${ac_cv_have___builtin_ctz}" = "xyes"], [
   AC_DEFINE([HAVE___BUILTIN_CTZ])
 ])
 
+AS_IF([test "x${ac_cv_c_compiler_gnu}" = "xyes"], [
+  CFLAGS="$CFLAGS -Wall"
+])
+
 AC_CONFIG_LINKS([
   cli/all-tests:cli/all-tests
   cli/fast-tests:cli/fast-tests


### PR DESCRIPTION
- configure.ac already has `-Wall` in `AM_INIT_AUTOMAKE` options,
  but it does _not_ affect the compiler:
  https://stackoverflow.com/questions/22152738

- cmake, on the other hand, doesn't have any warning options set,
  this patch does that along with autotools. (CC: @madebr)
