### PR TITLE
fix build with watcom compiler

### DIFF
--- a/cli/utils.c
+++ b/cli/utils.c
@@ -578,9 +578,10 @@ void finish_line (void)
 
     if (hConIn && GetConsoleScreenBufferInfo (hConIn, &coninfo) &&
         (coninfo.dwCursorPosition.X || coninfo.dwCursorPosition.Y)) {
-            COORD cpos = { coninfo.dwCursorPosition.X, coninfo.dwCursorPosition.Y };
             DWORD spaces = coninfo.dwSize.X - coninfo.dwCursorPosition.X, written;
-
+            COORD cpos;
+            cpos.X = coninfo.dwCursorPosition.X;
+            cpos.Y = coninfo.dwCursorPosition.Y;
             FillConsoleOutputCharacter (hConIn, ' ', spaces, cpos, &written);
             fprintf (stderr, "\n");
     }


### PR DESCRIPTION
fixes this build error:
```
utils.c(581): Error! E1054: Expression must be constant
utils.c(581): Error! E1054: Expression must be constant
```