### PR TITLE
fix several build issues, add version res to autotools windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2...3.5)
+cmake_minimum_required(VERSION 3.5)
 
 project(WavPack VERSION 5.6.6)
 
@@ -96,7 +96,9 @@ if(HAVE_LIBM)
     list(APPEND CMAKE_REQUIRED_LIBRARIES m)
 endif()
 
-find_package(Threads)
+if(NOT WIN32)
+  find_package(Threads)
+endif()
 find_package(Iconv)
 find_package(OpenSSL)
 
@@ -147,7 +149,7 @@ endif()
 # Dependent options
 
 cmake_dependent_option(WAVPACK_ENABLE_ASM "Enable assembly optimizations" ON "HAVE_ASM OR HAVE_MASM" OFF)
-cmake_dependent_option(WAVPACK_ENABLE_LIBCRYPTO "Use OpenSSL::Crypto library" ON "OPENSSL_FOUND" OFF)
+cmake_dependent_option(WAVPACK_ENABLE_LIBCRYPTO "Use OpenSSL::Crypto library" OFF "OPENSSL_FOUND" OFF)
 cmake_dependent_option(WAVPACK_BUILD_PROGRAMS "Build programs" ${WAVPACK_ROOTPROJECT} "WIN32 OR Iconv_FOUND" OFF)
 cmake_dependent_option(WAVPACK_BUILD_COOLEDIT_PLUGIN "Build CoolEdit plugin" ${WAVPACK_ROOTPROJECT} "WIN32" OFF)
 cmake_dependent_option(WAVPACK_BUILD_WINAMP_PLUGIN "Build WinAmp plugin" ${WAVPACK_ROOTPROJECT} "WIN32" OFF)
@@ -204,26 +206,10 @@ target_include_directories(wavpack
 )
 target_link_libraries(wavpack
     PRIVATE
-    $<$<BOOL:${WAVPACK_ENABLE_THREADS}>:Threads::Threads>
+        $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<BOOL:${WAVPACK_ENABLE_THREADS}>>:Threads::Threads>
         $<$<BOOL:${HAVE_LIBM}>:m>
 )
 add_library(WavPack::WavPack ALIAS wavpack)
-
-if(CMAKE_VERSION VERSION_LESS 3.4)
-    target_include_directories(wavpack
-        PRIVATE
-            $<$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>:${OPENSSL_INCLUDE_DIR}>
-    )
-    target_link_libraries(wavpack
-        PRIVATE
-            $<$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>:${OPENSSL_CRYPTO_LIBRARY}>
-    )
-else()
-    target_link_libraries(wavpack
-        PRIVATE
-            $<$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>:OpenSSL::Crypto>
-    )
-endif()
 
 target_compile_definitions(wavpack
     PRIVATE
@@ -233,7 +219,6 @@ target_compile_definitions(wavpack
         $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>
         $<$<BOOL:${HAVE___BUILTIN_CLZ}>:HAVE___BUILTIN_CLZ>
         $<$<BOOL:${HAVE_FSEEKO}>:HAVE_FSEEKO>
-        $<$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>:HAVE_LIBCRYPTO>
         $<$<AND:$<BOOL:${WAVPACK_ENABLE_ASM}>,$<BOOL:${CPU_ASM_X86}>>:OPT_ASM_X86>
         $<$<AND:$<BOOL:${WAVPACK_ENABLE_ASM}>,$<BOOL:${CPU_ASM_X64}>>:OPT_ASM_X64>
         $<$<AND:$<BOOL:${WAVPACK_ENABLE_ASM}>,$<BOOL:${CPU_ASM_ARM32}>>:OPT_ASM_ARM32>
@@ -406,6 +391,7 @@ if(WAVPACK_BUILD_PROGRAMS)
 	target_compile_definitions(wavpackapp
 		PRIVATE
 			$<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>
+			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:HAVE_LIBCRYPTO>
 			$<$<BOOL:${WAVPACK_ENABLE_THREADS}>:ENABLE_THREADS>
 			"PACKAGE_VERSION=\"${PROJECT_VERSION}\""
 			"VERSION_OS=\"${CMAKE_SYSTEM_NAME}\""
@@ -415,6 +401,7 @@ if(WAVPACK_BUILD_PROGRAMS)
 		PRIVATE
 			wavpack
 			$<$<NOT:$<BOOL:${WIN32}>>:Iconv::Iconv>
+			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:OpenSSL::Crypto>
 			$<$<BOOL:${HAVE_LIBM}>:m>
 	)
 
@@ -434,6 +421,7 @@ if(WAVPACK_BUILD_PROGRAMS)
 	target_compile_definitions(wvunpack
 		PRIVATE
 			$<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>
+			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:HAVE_LIBCRYPTO>
 			$<$<BOOL:${WAVPACK_ENABLE_THREADS}>:ENABLE_THREADS>
 			"PACKAGE_VERSION=\"${PROJECT_VERSION}\""
 			"VERSION_OS=\"${CMAKE_SYSTEM_NAME}\""
@@ -443,6 +431,7 @@ if(WAVPACK_BUILD_PROGRAMS)
 		PRIVATE
 			wavpack
 			$<$<NOT:$<BOOL:${WIN32}>>:Iconv::Iconv>
+			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:OpenSSL::Crypto>
 			$<$<BOOL:${HAVE_LIBM}>:m>
 	)
 
@@ -486,7 +475,6 @@ if(WAVPACK_BUILD_PROGRAMS)
 			$<$<NOT:$<BOOL:${WIN32}>>:Iconv::Iconv>
 			$<$<BOOL:${HAVE_LIBM}>:m>
 	)
-
 endif()
 
 if(WAVPACK_BUILD_COOLEDIT_PLUGIN)
@@ -585,9 +573,9 @@ set(WAVPACK_DOC_NAMES
 # Features
 
 set_package_properties(OpenSSL PROPERTIES
-	TYPE RECOMMENDED
+	TYPE OPTIONAL
 	DESCRIPTION "TLS/SSL and crypto library"
-    PURPOSE "Can be used to build wavpack library."
+    PURPOSE "Can be used to build programs."
 )
 
 set_package_properties(Iconv PROPERTIES
@@ -686,7 +674,7 @@ endif()
 # Tests
 
 if(BUILD_TESTING AND (NOT WIN32))
-
+    # FIXME: wvtest relies on pthreads only and doesn't use win32 threads
     enable_testing()
 
     add_executable(wvtest
@@ -697,14 +685,15 @@ if(BUILD_TESTING AND (NOT WIN32))
     )
     target_compile_definitions(wvtest
         PRIVATE
+            $<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:HAVE_LIBCRYPTO>
             "PACKAGE_VERSION=\"${PROJECT_VERSION}\""
             "VERSION_OS=\"${CMAKE_SYSTEM_NAME}\"")
     target_link_libraries(wvtest
         PRIVATE
             wavpack
             Threads::Threads
+            $<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:OpenSSL::Crypto>
             $<$<BOOL:${HAVE_LIBM}>:m>
     )
     add_test(NAME wvtest COMMAND $<TARGET_FILE:wvtest> --exhaustive --short --no-extras)
-
 endif()

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,9 +14,7 @@ EXTRA_DIST = \
 	CMakeLists.txt \
 	cmake/CheckCLinkerFlag.cmake \
 	cmake/modules/FindIconv.cmake \
-	cmake/TestLargeFiles.cmake \
-	wavpackdll/resource.h \
-	wavpackdll/wavpackdll.rc
+	cmake/TestLargeFiles.cmake
 
 MAINTAINERCLEANFILES = \
 	aclocal.m4 \
@@ -48,7 +46,7 @@ cli_wavpack_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 cli_wavpack_LDFLAGS = -rpath $(libdir)
 endif
-cli_wavpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV)
+cli_wavpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV) $(LIBCRYPTO)
 
 cli_wvunpack_SOURCES = cli/wvunpack.c cli/riff_write.c cli/wave64_write.c cli/caff_write.c cli/dsdiff_write.c cli/aiff_write.c cli/dsf_write.c cli/utils.c cli/md5.c
 if WINDOWS_HOST
@@ -58,7 +56,7 @@ cli_wvunpack_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 cli_wvunpack_LDFLAGS = -rpath $(libdir)
 endif
-cli_wvunpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV)
+cli_wvunpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV) $(LIBCRYPTO)
 
 cli_wvgain_SOURCES = cli/wvgain.c cli/utils.c
 if WINDOWS_HOST
@@ -80,16 +78,21 @@ cli_wvtag_LDFLAGS = -rpath $(libdir)
 endif
 cli_wvtag_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV)
 
+# FIXME: wvtest relies on pthreads only and doesn't use win32 threads
+if WINDOWS_HOST
+check_PROGRAMS =
+else
 check_PROGRAMS = cli/wvtest
 cli_wvtest_SOURCES = cli/wvtest.c cli/md5.c
 cli_wvtest_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 cli_wvtest_LDFLAGS = -rpath $(libdir)
 endif
-cli_wvtest_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) -lpthread
+cli_wvtest_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBCRYPTO) $(LIBTHREAD)
 
 TESTS = cli/fast-tests
 TESTS_ENVIRONMENT = $(SHELL)
+endif
 
 noinst_HEADERS = \
 	cli/win32_unicode_support.h \
@@ -162,6 +165,18 @@ if ENABLE_ARMASM
 src_libwavpack_la_SOURCES += src/unpack_armv7.S
 endif
 
+if WINDOWS_HOST
+if HAVE_WINDRES
+src_libwavpack_la_SOURCES += wavpackdll/dummy.c wavpackdll/wavpackdll.rc wavpackdll/resource.h
+src_libwavpack_la_DEPENDENCIES = wavpackdll/wavpackdll.o
+win32res_link = -Wl,wavpackdll/wavpackdll.o
+wavpackdll/wavpackdll.o: wavpackdll/wavpackdll.rc
+endif
+endif
+
 src_libwavpack_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
-src_libwavpack_la_LIBADD = $(AM_LDADD) $(LIBM) -lpthread
-src_libwavpack_la_LDFLAGS = -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) -export-symbols-regex '^Wavpack.*$$' -no-undefined
+src_libwavpack_la_LIBADD = $(AM_LDADD) $(LIBM) $(LIBTHREAD)
+src_libwavpack_la_LDFLAGS = -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) $(win32res_link) -export-symbols-regex '^Wavpack.*$$' -no-undefined
+
+.rc.o:
+	$(RC) $(AM_CPPFLAGS) -i $< $@

--- a/configure.ac
+++ b/configure.ac
@@ -34,9 +34,10 @@ AC_DEFINE_UNQUOTED([VERSION_OS], ["${host_os}"], [os version])
 
 dnl Checks for programs.
 AC_PROG_CC
-AC_PROG_INSTALL
 AM_PROG_AR
 AM_PROG_AS
+AC_CHECK_TOOL(RC,[windres],[:])
+AC_PROG_INSTALL
 
 LT_INIT([win32-dll disable-static])
 
@@ -70,8 +71,14 @@ AS_IF([test "x${enable_apps}" != "xno" && test "x${windows_host}" != "xyes"], [
 ])
 
 AS_IF([test "x${enable_libcrypto}" = "xyes"], [
+  save_LIBS="$LIBS"
   AC_CHECK_LIB([crypto],[MD5_Init])
+  LIBS="$save_LIBS"
+  AS_IF([test "x${ac_cv_lib_crypto_MD5_Init}" = "xyes"], [
+    LIBCRYPTO="-lcrypto"
+  ])
 ])
+AC_SUBST([LIBCRYPTO])
 
 AC_ARG_ENABLE([legacy],
   [AS_HELP_STRING([--enable-legacy], [decode legacy (< 4.0) WavPack files])])
@@ -91,7 +98,11 @@ AC_ARG_ENABLE([threads],
   [AS_HELP_STRING([--disable-threads], [disable use of threading in libwavpack])])
 AS_IF([test "x${enable_threads}" != "xno"], [
   AC_DEFINE([ENABLE_THREADS])
+  AS_IF([test "x${windows_host}" != "xyes"], [
+    LIBTHREAD="-lpthread"
+  ])
 ])
+AC_SUBST([LIBTHREAD])
 AM_CONDITIONAL([ENABLE_THREADS], [test "x${enable_threads}" != "xno"])
 
 AC_ARG_ENABLE([rpath],
@@ -150,6 +161,11 @@ AS_IF([test "x${ac_cv_have___builtin_ctz}" = "xyes"], [
 AS_IF([test "x${ac_cv_c_compiler_gnu}" = "xyes"], [
   CFLAGS="$CFLAGS -Wall"
 ])
+
+AS_IF([test "x${windows_host}" = "xyes"], [
+  AS_IF([test "x$RC" != "x:"],[have_windres=true])
+])
+AM_CONDITIONAL([HAVE_WINDRES],[test "x$have_windres" = "xtrue"])
 
 AC_CONFIG_LINKS([
   cli/all-tests:cli/all-tests


### PR DESCRIPTION
- autotools: add version resource to libwavpack windows builds.
- autotools: link libcryto only to its users, not everything.
- autotools: don't link with pthread when targeting windows where it's
  not used and need not be available.
- cmake: fix openssl/libcrypto usage: it minked it to libwavpack where
  it isn't used and not the programs where it actually matters.
- cmake: bumped minimum required version to 3.5 to ease the use of ssl
  options.
- cmake: disable libcrypto by default so it matches autotools and it's
  noted that it breaks macOS builds.
- cmake: fix the purpose description of openssl package.
- cmake: only do find_package(Threads) for non-windows: otherwise it'd
  find pthreads which may be available in mingw toolchains.

Build tested using autotools and cmake targeting linux and windows (mingw)

Please review / test for any gotchas.

Cmake changes are least readable, at least for me, because of millions of
brackets, but builds were OK at my end. @madebr can verify.

P.S.: @dbry: If you want libcryto removed, I can change the patch for it.

P.S./2: I couldn't break the patch into smaller pieces doing one thing at
a time: they'd be inter-dependendent too much.
