### PR TITLE
remove optional openssl libcrypt dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.2...3.5)
 
 project(WavPack VERSION 5.6.6)
 
@@ -78,7 +78,6 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(FeatureSummary)
 include(CPack)
-include(FindOpenSSL)
 
 # Options. See also dependent options below
 
@@ -100,7 +99,6 @@ if(NOT WIN32)
   find_package(Threads)
 endif()
 find_package(Iconv)
-find_package(OpenSSL)
 
 check_c_source_compiles(
         "int main()
@@ -149,7 +147,6 @@ endif()
 # Dependent options
 
 cmake_dependent_option(WAVPACK_ENABLE_ASM "Enable assembly optimizations" ON "HAVE_ASM OR HAVE_MASM" OFF)
-cmake_dependent_option(WAVPACK_ENABLE_LIBCRYPTO "Use OpenSSL::Crypto library" OFF "OPENSSL_FOUND" OFF)
 cmake_dependent_option(WAVPACK_BUILD_PROGRAMS "Build programs" ${WAVPACK_ROOTPROJECT} "WIN32 OR Iconv_FOUND" OFF)
 cmake_dependent_option(WAVPACK_BUILD_COOLEDIT_PLUGIN "Build CoolEdit plugin" ${WAVPACK_ROOTPROJECT} "WIN32" OFF)
 cmake_dependent_option(WAVPACK_BUILD_WINAMP_PLUGIN "Build WinAmp plugin" ${WAVPACK_ROOTPROJECT} "WIN32" OFF)
@@ -391,7 +388,6 @@ if(WAVPACK_BUILD_PROGRAMS)
 	target_compile_definitions(wavpackapp
 		PRIVATE
 			$<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>
-			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:HAVE_LIBCRYPTO>
 			$<$<BOOL:${WAVPACK_ENABLE_THREADS}>:ENABLE_THREADS>
 			"PACKAGE_VERSION=\"${PROJECT_VERSION}\""
 			"VERSION_OS=\"${CMAKE_SYSTEM_NAME}\""
@@ -401,7 +397,6 @@ if(WAVPACK_BUILD_PROGRAMS)
 		PRIVATE
 			wavpack
 			$<$<NOT:$<BOOL:${WIN32}>>:Iconv::Iconv>
-			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:OpenSSL::Crypto>
 			$<$<BOOL:${HAVE_LIBM}>:m>
 	)
 
@@ -421,7 +416,6 @@ if(WAVPACK_BUILD_PROGRAMS)
 	target_compile_definitions(wvunpack
 		PRIVATE
 			$<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>
-			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:HAVE_LIBCRYPTO>
 			$<$<BOOL:${WAVPACK_ENABLE_THREADS}>:ENABLE_THREADS>
 			"PACKAGE_VERSION=\"${PROJECT_VERSION}\""
 			"VERSION_OS=\"${CMAKE_SYSTEM_NAME}\""
@@ -431,7 +425,6 @@ if(WAVPACK_BUILD_PROGRAMS)
 		PRIVATE
 			wavpack
 			$<$<NOT:$<BOOL:${WIN32}>>:Iconv::Iconv>
-			$<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:OpenSSL::Crypto>
 			$<$<BOOL:${HAVE_LIBM}>:m>
 	)
 
@@ -570,13 +563,8 @@ set(WAVPACK_DOC_NAMES
     wvtag
 )
 
-# Features
 
-set_package_properties(OpenSSL PROPERTIES
-	TYPE OPTIONAL
-	DESCRIPTION "TLS/SSL and crypto library"
-    PURPOSE "Can be used to build programs."
-)
+# Features
 
 set_package_properties(Iconv PROPERTIES
 	TYPE RECOMMENDED
@@ -596,9 +584,7 @@ add_feature_info(WAVPACK_ENABLE_DSD WAVPACK_ENABLE_DSD "Enable support for WavPa
 add_feature_info(WAVPACK_ENABLE_THREADS WAVPACK_ENABLE_THREADS "Enable support for threading in libwavpack.")
 add_feature_info(WAVPACK_INSTALL_CMAKE_MODULE WAVPACK_INSTALL_CMAKE_MODULE "Generate and install CMake package configuration module.")
 
-
 add_feature_info(WAVPACK_ENABLE_ASM WAVPACK_ENABLE_ASM "Enable assembly optimizations.")
-add_feature_info(WAVPACK_ENABLE_LIBCRYPTO WAVPACK_ENABLE_LIBCRYPTO "Use OpenSSL::Crypto library.")
 add_feature_info(WAVPACK_BUILD_PROGRAMS WAVPACK_BUILD_PROGRAMS "Build programs.")
 add_feature_info(WAVPACK_BUILD_COOLEDIT_PLUGIN WAVPACK_BUILD_COOLEDIT_PLUGIN "Build CoolEdit plugin.")
 add_feature_info(WAVPACK_BUILD_WINAMP_PLUGIN WAVPACK_BUILD_WINAMP_PLUGIN "Build WinAmp plugin.")
@@ -606,6 +592,7 @@ add_feature_info(WAVPACK_INSTALL_DOCS WAVPACK_INSTALL_DOCS "Install documentatio
 add_feature_info(WAVPACK_INSTALL_PKGCONFIG_MODULE WAVPACK_INSTALL_PKGCONFIG_MODULE "Generate and install wavpack.pc.")
 
 feature_summary(WHAT ALL)
+
 
 # Installation
 
@@ -685,14 +672,12 @@ if(BUILD_TESTING AND (NOT WIN32))
     )
     target_compile_definitions(wvtest
         PRIVATE
-            $<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:HAVE_LIBCRYPTO>
             "PACKAGE_VERSION=\"${PROJECT_VERSION}\""
             "VERSION_OS=\"${CMAKE_SYSTEM_NAME}\"")
     target_link_libraries(wvtest
         PRIVATE
             wavpack
             Threads::Threads
-            $<$<AND:$<BOOL:${WAVPACK_ENABLE_LIBCRYPTO}>,$<BOOL:${OPENSSL_FOUND}>>:OpenSSL::Crypto>
             $<$<BOOL:${HAVE_LIBM}>:m>
     )
     add_test(NAME wvtest COMMAND $<TARGET_FILE:wvtest> --exhaustive --short --no-extras)

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ cli_wavpack_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 cli_wavpack_LDFLAGS = -rpath $(libdir)
 endif
-cli_wavpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV) $(LIBCRYPTO)
+cli_wavpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV)
 
 cli_wvunpack_SOURCES = cli/wvunpack.c cli/riff_write.c cli/wave64_write.c cli/caff_write.c cli/dsdiff_write.c cli/aiff_write.c cli/dsf_write.c cli/utils.c cli/md5.c
 if WINDOWS_HOST
@@ -56,7 +56,7 @@ cli_wvunpack_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 cli_wvunpack_LDFLAGS = -rpath $(libdir)
 endif
-cli_wvunpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV) $(LIBCRYPTO)
+cli_wvunpack_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBICONV)
 
 cli_wvgain_SOURCES = cli/wvgain.c cli/utils.c
 if WINDOWS_HOST
@@ -88,7 +88,7 @@ cli_wvtest_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
 if ENABLE_RPATH
 cli_wvtest_LDFLAGS = -rpath $(libdir)
 endif
-cli_wvtest_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBCRYPTO) $(LIBTHREAD)
+cli_wvtest_LDADD = $(AM_LDADD) src/libwavpack.la $(LIBM) $(LIBTHREAD)
 
 TESTS = cli/fast-tests
 TESTS_ENVIRONMENT = $(SHELL)

--- a/cli/md5.c
+++ b/cli/md5.c
@@ -35,8 +35,6 @@
  * compile-time configuration.
  */
 
-#ifndef HAVE_LIBCRYPTO
-
 #include <string.h>
 
 #include "md5.h"
@@ -287,5 +285,3 @@ void MD5_Final(unsigned char *result, MD5_CTX *ctx)
 
 	memset(ctx, 0, sizeof(*ctx));
 }
-
-#endif

--- a/cli/md5.h
+++ b/cli/md5.h
@@ -22,10 +22,7 @@
  *
  * See md5.c for more information.
  */
-
-#ifdef HAVE_LIBCRYPTO
-#include <openssl/md5.h>
-#elif !defined(_MD5_H)
+#ifndef _MD5_H
 #define _MD5_H
 
 /* Any 32-bit or wider unsigned integer data type will do */

--- a/configure.ac
+++ b/configure.ac
@@ -48,9 +48,6 @@ dnl Check for large files support
 AC_SYS_LARGEFILE
 AC_FUNC_FSEEKO
 
-AC_ARG_ENABLE([libcrypto],
-  [AS_HELP_STRING([--enable-libcrypto], [use libcrypto MD5 if available (breaks Mac build)])])
-
 AC_ARG_ENABLE([apps],
   [AS_HELP_STRING([--disable-apps], [build only libwavpack (removes ICONV dependency)])])
 AM_CONDITIONAL([ENABLE_APPS], [test "x${enable_apps}" != "xno"])
@@ -69,16 +66,6 @@ AS_IF([test "x${enable_apps}" != "xno" && test "x${windows_host}" != "xyes"], [
     AC_MSG_ERROR([iconv is required for apps, use --disable-apps to build only libwavpack])
   ])
 ])
-
-AS_IF([test "x${enable_libcrypto}" = "xyes"], [
-  save_LIBS="$LIBS"
-  AC_CHECK_LIB([crypto],[MD5_Init])
-  LIBS="$save_LIBS"
-  AS_IF([test "x${ac_cv_lib_crypto_MD5_Init}" = "xyes"], [
-    LIBCRYPTO="-lcrypto"
-  ])
-])
-AC_SUBST([LIBCRYPTO])
 
 AC_ARG_ENABLE([legacy],
   [AS_HELP_STRING([--enable-legacy], [decode legacy (< 4.0) WavPack files])])


### PR DESCRIPTION
It isn't a part of libwavpack, only used if you specify -m or -v on the program command-line, makes only a negligible difference in performance. It causes trouble for Apple too because the API is different. Therefore, it's not worth the complexity.