### PR TITLE
Makefile.am: add src/wavpack.exports to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,7 @@ EXTRA_DIST = \
 	cli/Makefile.w32 \
 	src/Makefile.os2 \
 	src/Makefile.w32 \
+	src/wavpack.exports \
 	src/pack_x64.asm \
 	src/pack_x86.asm \
 	src/unpack_x64.asm \


### PR DESCRIPTION
(was missed in c01d06d3f969ae7cd0bb32e95271ca189dce1840)