### PR TITLE
eliminate use of '&' address-of operator on arrays (take/2.)

### DIFF
--- a/src/decorr_utils.c
+++ b/src/decorr_utils.c
@@ -99,8 +99,8 @@ int read_decorr_samples (WavpackStream *wps, WavpackMetadata *wpmd)
     int tcount;
 
     for (tcount = wps->num_terms, dpp = wps->decorr_passes; tcount--; dpp++) {
-        CLEAR (dpp->samples_A);
-        CLEAR (dpp->samples_B);
+        CLEARA (dpp->samples_A);
+        CLEARA (dpp->samples_B);
     }
 
     if (wps->wphdr.version == 0x402 && (wps->wphdr.flags & HYBRID_FLAG)) {

--- a/src/extra1.c
+++ b/src/extra1.c
@@ -193,7 +193,7 @@ static void decorr_mono_buffer (int32_t *samples, int32_t *outsamples, uint32_t 
     if (tindex == 0)
         reverse_mono_decorr (&dp);
     else
-        CLEAR (dp.samples_A);
+        CLEARA (dp.samples_A);
 
     memcpy (dppi->samples_A, dp.samples_A, sizeof (dp.samples_A));
     dppi->weight_A = dp.weight_A;
@@ -257,7 +257,7 @@ static void recurse_mono (WavpackStream *wps, WavpackExtraInfo *info, int depth,
 
         if (bits < info->best_bits) {
             info->best_bits = bits;
-            CLEAR (wps->decorr_passes);
+            CLEARA (wps->decorr_passes);
             memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * (depth + 1));
             memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [depth + 1], wps->wphdr.block_samples * 4);
         }
@@ -322,7 +322,7 @@ static void delta_mono (WavpackStream *wps, WavpackExtraInfo *info)
         if (bits < info->best_bits) {
             lower = TRUE;
             info->best_bits = bits;
-            CLEAR (wps->decorr_passes);
+            CLEARA (wps->decorr_passes);
             memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * i);
             memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [i], wps->wphdr.block_samples * 4);
         }
@@ -346,7 +346,7 @@ static void delta_mono (WavpackStream *wps, WavpackExtraInfo *info)
 
         if (bits < info->best_bits) {
             info->best_bits = bits;
-            CLEAR (wps->decorr_passes);
+            CLEARA (wps->decorr_passes);
             memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * i);
             memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [i], wps->wphdr.block_samples * 4);
         }
@@ -390,7 +390,7 @@ static void sort_mono (WavpackStream *wps, WavpackExtraInfo *info)
             if (bits < info->best_bits) {
                 reversed = TRUE;
                 info->best_bits = bits;
-                CLEAR (wps->decorr_passes);
+                CLEARA (wps->decorr_passes);
                 memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * i);
                 memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [i], wps->wphdr.block_samples * 4);
             }
@@ -473,7 +473,7 @@ static void analyze_mono (WavpackStream *wps, int32_t *samples, int do_samples)
 
 static void mono_add_noise (WavpackStream *wps, int32_t *lptr, int32_t *rptr)
 {
-    int shaping_weight, new = wps->wphdr.flags & NEW_SHAPING;
+    int shaping_weight, is_new = wps->wphdr.flags & NEW_SHAPING;
     short *shaping_array = wps->dc.shaping_array;
     int32_t error = 0, temp, cnt;
 
@@ -489,7 +489,7 @@ static void mono_add_noise (WavpackStream *wps, int32_t *lptr, int32_t *rptr)
 
             temp = -apply_weight (shaping_weight, error);
 
-            if (new && shaping_weight < 0 && temp) {
+            if (is_new && shaping_weight < 0 && temp) {
                 if (temp == error)
                     temp = (temp < 0) ? temp + 1 : temp - 1;
 
@@ -533,7 +533,7 @@ void execute_mono (WavpackStream *wps, int32_t *samples, int no_history, int do_
             break;
 
     if (i == num_samples) {
-        CLEAR (wps->decorr_passes);
+        CLEARA (wps->decorr_passes);
         wps->num_terms = 0;
         init_words (wps);
         return;
@@ -617,7 +617,7 @@ void execute_mono (WavpackStream *wps, int32_t *samples, int no_history, int do_
                 num_samples > 2048 ? 2048 : num_samples, &temp_decorr_pass, -1);
 
             if (j) {
-                CLEAR (temp_decorr_pass.samples_A);
+                CLEARA (temp_decorr_pass.samples_A);
             }
             else
                 reverse_mono_decorr (&temp_decorr_pass);

--- a/src/extra2.c
+++ b/src/extra2.c
@@ -346,8 +346,8 @@ static void decorr_stereo_buffer (WavpackExtraInfo *info, int32_t *samples, int3
     if (tindex == 0)
         reverse_decorr (&dp);
     else {
-        CLEAR (dp.samples_A);
-        CLEAR (dp.samples_B);
+        CLEARA (dp.samples_A);
+        CLEARA (dp.samples_B);
     }
 
     memcpy (dppi->samples_A, dp.samples_A, sizeof (dp.samples_A));
@@ -420,7 +420,7 @@ static void recurse_stereo (WavpackStream *wps, WavpackExtraInfo *info, int dept
 
         if (bits < info->best_bits) {
             info->best_bits = bits;
-            CLEAR (wps->decorr_passes);
+            CLEARA (wps->decorr_passes);
             memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * (depth + 1));
             memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [depth + 1], wps->wphdr.block_samples * 8);
         }
@@ -486,7 +486,7 @@ static void delta_stereo (WavpackStream *wps, WavpackExtraInfo *info)
         if (bits < info->best_bits) {
             lower = TRUE;
             info->best_bits = bits;
-            CLEAR (wps->decorr_passes);
+            CLEARA (wps->decorr_passes);
             memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * i);
             memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [i], wps->wphdr.block_samples * 8);
         }
@@ -510,7 +510,7 @@ static void delta_stereo (WavpackStream *wps, WavpackExtraInfo *info)
 
         if (bits < info->best_bits) {
             info->best_bits = bits;
-            CLEAR (wps->decorr_passes);
+            CLEARA (wps->decorr_passes);
             memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * i);
             memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [i], wps->wphdr.block_samples * 8);
         }
@@ -554,7 +554,7 @@ static void sort_stereo (WavpackStream *wps, WavpackExtraInfo *info)
             if (bits < info->best_bits) {
                 reversed = TRUE;
                 info->best_bits = bits;
-                CLEAR (wps->decorr_passes);
+                CLEARA (wps->decorr_passes);
                 memcpy (wps->decorr_passes, info->dps, sizeof (info->dps [0]) * i);
                 memcpy (info->sampleptrs [info->nterms + 1], info->sampleptrs [i], wps->wphdr.block_samples * 8);
             }
@@ -637,7 +637,7 @@ static void analyze_stereo (WavpackStream *wps, int32_t *samples, int do_samples
 
 static void stereo_add_noise (WavpackStream *wps, int32_t *lptr, int32_t *rptr)
 {
-    int shaping_weight, new = wps->wphdr.flags & NEW_SHAPING;
+    int shaping_weight, is_new = wps->wphdr.flags & NEW_SHAPING;
     short *shaping_array = wps->dc.shaping_array;
     int32_t error [2], temp, cnt;
 
@@ -655,7 +655,7 @@ static void stereo_add_noise (WavpackStream *wps, int32_t *lptr, int32_t *rptr)
 
             temp = -apply_weight (shaping_weight, error [0]);
 
-            if (new && shaping_weight < 0 && temp) {
+            if (is_new && shaping_weight < 0 && temp) {
                 if (temp == error [0])
                     temp = (temp < 0) ? temp + 1 : temp - 1;
 
@@ -669,7 +669,7 @@ static void stereo_add_noise (WavpackStream *wps, int32_t *lptr, int32_t *rptr)
 
             temp = -apply_weight (shaping_weight, error [1]);
 
-            if (new && shaping_weight < 0 && temp) {
+            if (is_new && shaping_weight < 0 && temp) {
                 if (temp == error [1])
                     temp = (temp < 0) ? temp + 1 : temp - 1;
 
@@ -717,7 +717,7 @@ void execute_stereo (WavpackStream *wps, int32_t *samples, int no_history, int d
 
     if (i == num_samples * 2) {
         wps->wphdr.flags &= ~((uint32_t) JOINT_STEREO);
-        CLEAR (wps->decorr_passes);
+        CLEARA (wps->decorr_passes);
         wps->num_terms = 0;
         init_words (wps);
         return;
@@ -825,8 +825,8 @@ void execute_stereo (WavpackStream *wps, int32_t *samples, int no_history, int d
                     num_samples > 2048 ? 2048 : num_samples, &temp_decorr_pass, -1);
 
                 if (j) {
-                    CLEAR (temp_decorr_pass.samples_A);
-                    CLEAR (temp_decorr_pass.samples_B);
+                    CLEARA (temp_decorr_pass.samples_A);
+                    CLEARA (temp_decorr_pass.samples_B);
                 }
                 else
                     reverse_decorr (&temp_decorr_pass);

--- a/src/open_utils.c
+++ b/src/open_utils.c
@@ -321,7 +321,7 @@ int unpack_init (WavpackContext *wpc, int stream)
     CLEAR (wps->wvbits);
     CLEAR (wps->wvcbits);
     CLEAR (wps->wvxbits);
-    CLEAR (wps->decorr_passes);
+    CLEARA(wps->decorr_passes);
     CLEAR (wps->dc);
     CLEAR (wps->w);
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -34,7 +34,7 @@ void pack_init (WavpackStream *wps)
 {
     wps->num_terms = 0;
     wps->dc.error [0] = wps->dc.error [1] = 0;
-    CLEAR (wps->decorr_passes);
+    CLEARA (wps->decorr_passes);
     CLEAR (wps->dc);
 
     if (wps->delta_decay == 0.0)
@@ -215,8 +215,8 @@ static void write_decorr_samples (WavpackStream *wps, WavpackMetadata *wpmd)
             wcount--;
         }
         else {
-            CLEAR (dpp->samples_A);
-            CLEAR (dpp->samples_B);
+            CLEARA (dpp->samples_A);
+            CLEARA (dpp->samples_B);
         }
 
     wpmd->byte_length = (int32_t)(byteptr - (unsigned char *) wpmd->data);
@@ -1499,8 +1499,8 @@ static int pack_samples (WavpackStream *wps, int32_t *buffer)
 
                 for (ti = wps->num_terms; ti < saved_stream.num_terms; ++ti) {
                     wps->decorr_passes [ti].weight_A = wps->decorr_passes [ti].weight_B = 0;
-                    CLEAR (wps->decorr_passes [ti].samples_A);
-                    CLEAR (wps->decorr_passes [ti].samples_B);
+                    CLEARA (wps->decorr_passes [ti].samples_A);
+                    CLEARA (wps->decorr_passes [ti].samples_B);
                 }
 
                 wps->num_terms = saved_stream.num_terms;

--- a/src/read_words.c
+++ b/src/read_words.c
@@ -113,8 +113,8 @@ int32_t FASTCALL get_word (WavpackStream *wps, int chan, int32_t *correction)
 
             if (wps->w.zeros_acc) {
                 c->slow_level -= (c->slow_level + SLO) >> SLS;
-                CLEAR (wps->w.c [0].median);
-                CLEAR (wps->w.c [1].median);
+                CLEARA (wps->w.c [0].median);
+                CLEARA (wps->w.c [1].median);
                 return 0;
             }
         }
@@ -396,8 +396,8 @@ int32_t get_words_lossless (WavpackStream *wps, int32_t *buffer, int32_t nsample
                 }
 
                 if (wps->w.zeros_acc) {
-                    CLEAR (wps->w.c [0].median);
-                    CLEAR (wps->w.c [1].median);
+                    CLEARA (wps->w.c [0].median);
+                    CLEARA (wps->w.c [1].median);
                     buffer [csamples] = 0;
                     continue;
                 }

--- a/src/unpack3.c
+++ b/src/unpack3.c
@@ -75,7 +75,7 @@ void unpack_init3 (WavpackStream3 *wps)
     struct decorr_pass *dpp;
     int ti;
 
-    CLEAR (wps->decorr_passes);
+    CLEARA(wps->decorr_passes);
     CLEAR (wps->dc);
 
     if (flags & EXTREME_DECORR) {
@@ -187,7 +187,7 @@ static void *unpack_save (WavpackStream3 *wps, void *destin)
         SAVE (destin, wps->w2);
 
     if (wps->wphdr.bits) {
-        SAVE (destin, wps->dc.error);
+        SAVEA(destin, wps->dc.error);
     }
     else {
         SAVE (destin, wps->dc.sum_level);
@@ -202,8 +202,8 @@ static void *unpack_save (WavpackStream3 *wps, void *destin)
     }
 
     if (!(flags & EXTREME_DECORR)) {
-        SAVE (destin, wps->dc.sample);
-        SAVE (destin, wps->dc.weight);
+        SAVEA(destin, wps->dc.sample);
+        SAVEA(destin, wps->dc.weight);
     }
 
     if (flags & (HIGH_FLAG | NEW_HIGH_FLAG))

--- a/src/unpack3.h
+++ b/src/unpack3.h
@@ -115,5 +115,8 @@ typedef struct {
 
 #define SAVE(destin, item) { memcpy (destin, &item, sizeof (item)); destin = (char *) destin + sizeof (item); }
 #define RESTORE(item, source) { memcpy (&item, source, sizeof (item)); source = (char *) source + sizeof (item); }
+/* same as above, but for when 'item' is an array:  */
+#define SAVEA(destin, item) { memcpy (destin, item, sizeof (item)); destin = (char *) destin + sizeof (item); }
+#define RESTOREA(item, source) { memcpy (item, source, sizeof (item)); source = (char *) source + sizeof (item); }
 
 void unpack_init3 (WavpackStream3 *wps);

--- a/src/unpack3_seek.c
+++ b/src/unpack3_seek.c
@@ -133,7 +133,7 @@ static void *unpack_restore (WavpackStream3 *wps, void *source, int keep_resourc
         RESTORE (wps->w2, source);
 
     if (wps->wphdr.bits) {
-        RESTORE (wps->dc.error, source);
+        RESTOREA(wps->dc.error, source);
     }
     else {
         RESTORE (wps->dc.sum_level, source);
@@ -148,8 +148,8 @@ static void *unpack_restore (WavpackStream3 *wps, void *source, int keep_resourc
     }
 
     if (!(flags & EXTREME_DECORR)) {
-        RESTORE (wps->dc.sample, source);
-        RESTORE (wps->dc.weight, source);
+        RESTOREA (wps->dc.sample, source);
+        RESTOREA (wps->dc.weight, source);
     }
 
     if (flags & (HIGH_FLAG | NEW_HIGH_FLAG))

--- a/src/write_words.c
+++ b/src/write_words.c
@@ -200,8 +200,8 @@ int32_t FASTCALL send_word (WavpackStream *wps, int32_t value, int chan)
             putbit_0 (&wps->wvbits);
         else {
             c->slow_level -= (c->slow_level + SLO) >> SLS;
-            CLEAR (wps->w.c [0].median);
-            CLEAR (wps->w.c [1].median);
+            CLEARA (wps->w.c [0].median);
+            CLEARA (wps->w.c [1].median);
             wps->w.zeros_acc = 1;
             return 0;
         }
@@ -356,8 +356,8 @@ void send_words_lossless (WavpackStream *wps, int32_t *buffer, int32_t nsamples)
             else if (value)
                 putbit_0 (&wps->wvbits);
             else {
-                CLEAR (wps->w.c [0].median);
-                CLEAR (wps->w.c [1].median);
+                CLEARA (wps->w.c [0].median);
+                CLEARA (wps->w.c [1].median);
                 wps->w.zeros_acc = 1;
                 continue;
             }


### PR DESCRIPTION
This is an extension of PR #130, where the compiler missed several
cases because of a bug [1]. (These ones were revealed by using the
c++ compiler instead.)

[1] https://github.com/open-watcom/open-watcom-v2/issues/1158
