### PR TITLE
cli: support detecting cores in macOS and BSDs

### DIFF
--- a/cli/utils.c
+++ b/cli/utils.c
@@ -671,7 +671,9 @@ int check_break (void)
 
 #ifdef ENABLE_THREADS
 
-#if defined(__GNUC__) && !defined(_WIN32)
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#include <sys/sysctl.h>
+#elif defined(__GNUC__) && !defined(_WIN32)
 #include <sys/sysinfo.h>
 #endif
 
@@ -683,6 +685,10 @@ int get_default_worker_threads (void)
     SYSTEM_INFO sysinfo;
     GetSystemInfo (&sysinfo);
     num_processors = sysinfo.dwNumberOfProcessors;
+#elif defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+    size_t len = sizeof (num_processors);
+    int mib[2] = { CTL_HW, HW_NCPU };
+    sysctl (mib, 2, &num_processors, &len, NULL, 0);
 #elif defined (__GNUC__)
     num_processors = get_nprocs ();
 #endif


### PR DESCRIPTION
Follow-up to 8b5b1f54863c2b3b2d578d3c4c8434a7447134e5. macOS does not have `sys/sysinfo.h`, nor does it have `get_nprocs(3)`. On macOS, use `sysctlbyname(3)` in `sys/sysctl.h` instead.

This change addresses #195. I have tried to scope the preprocessor macros as narrowly as possible, so as to avoid impacting other *nix distributions. Note that `sys/sysinfo.h` and `get_nprocs(3)` are Linux extensions, not standardized by POSIX (although some ports of it to e.g. FreeBSD might exist). So I suspect some other *nix platforms may also be impacted by the aforementioned commit.