### PR TITLE
include intrin.h in MSVC builds for BitScanXXX.

### DIFF
--- a/src/read_words.c
+++ b/src/read_words.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_MSC_VER) && defined(__clang__)
+#if defined(_MSC_VER)
 #include <intrin.h>
 #endif
 

--- a/src/wavpack_local.h
+++ b/src/wavpack_local.h
@@ -634,6 +634,9 @@ extern __inline int _bsr_watcom(uint32_t);
   modify exact [eax] nomemory;
 #define count_bits(av) ((av) ? _bsr_watcom((av)) + 1 : 0)
 #elif defined (_WIN64)
+ #ifdef _MSC_VER
+ #include <intrin.h>
+ #endif
 static __inline int count_bits (uint32_t av) { unsigned long res; return _BitScanReverse (&res, av) ? (int)(res + 1) : 0; }
 #else
 #define count_bits(av) ( \


### PR DESCRIPTION
also remove clang-cl restriction in read_words.c and always include intrin.h for MSVC.
