### PR TITLE
Fix autoreconf with gettext 0.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install packages
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: sudo apt install -y git tar gcc g++ make autoconf gettext
+        run: sudo apt install -y git tar gcc g++ make autoconf autopoint gettext
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS =
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = wavpack.pc
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,10 @@ dnl wavpack 5.8.1 configure.ac
 
 AC_INIT([wavpack], [5.8.1], [bryant@wavpack.com])
 AC_CONFIG_SRCDIR([src/pack.c])
+AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([-Wall 1.15 serial-tests subdir-objects foreign no-dist-gzip dist-xz])
+AM_GNU_GETTEXT_VERSION([0.21])
+AM_GNU_GETTEXT([external])
 AM_MAINTAINER_MODE
 
 LIBWAVPACK_MAJOR=5


### PR DESCRIPTION
Since gettext 0.25, the AM_ICONV macro is installed into the m4 directory, so we need to add that autoconf config directory.  We also need to make sure autoreconf recognizes that it needs to run autopoint to install the gettext macros, which it does heuristically by checking whether AM_GNU_GETTEXT_VERSION is used, so add that and the minimum amount of other stuff required to make it happy.  The version of gettext we say we use shouldn't matter, so I just went with the version in ubuntu:latest since that's what CI uses.