### PR TITLE
wvunpack.c: fix the message about extra/missing samples

### DIFF
--- a/cli/wvunpack.c
+++ b/cli/wvunpack.c
@@ -1526,9 +1526,9 @@ static int quick_verify_file (char *infilename, int verbose)
 
     if (total_samples != -1 && total_samples != block_index) {
         if (total_samples < block_index)
-            error_line ("quick verify: WavPack file contains %lld extra samples!", block_samples - total_samples);
+            error_line ("quick verify: WavPack file contains %lld extra samples!", block_index - total_samples);
         else
-            error_line ("quick verify: WavPack file is missing %lld samples!", total_samples - block_samples);
+            error_line ("quick verify: WavPack file is missing %lld samples!", total_samples - block_index);
 
         return WAVPACK_SOFT_ERROR;
     }


### PR DESCRIPTION
proper variable name in expression