### PR TITLE
fix 'incompatible pointer type' warnings if int32_t is defined as long

### DIFF
--- a/src/pack_dsd.c
+++ b/src/pack_dsd.c
@@ -447,7 +447,7 @@ static int encode_buffer_fast (WavpackStream *wps, int32_t *buffer, int num_samp
 
 #define RATE_S 20
 
-static void init_ptable (int *table, int rate_i, int rate_s)
+static void init_ptable (int32_t *table, int rate_i, int rate_s)
 {
     int value = 0x808000, rate = rate_i << 8, c, i;
 
@@ -467,10 +467,10 @@ static void init_ptable (int *table, int rate_i, int rate_s)
     }
 }
 
-static int normalize_ptable (int *ptable)
+static int normalize_ptable (int32_t *ptable)
 {
     int rate = 0, min_error, error_sum, i;
-    int ntable [PTABLE_BINS];
+    int32_t ntable [PTABLE_BINS];
 
     init_ptable (ntable, rate, RATE_S);
 

--- a/src/unpack_dsd.c
+++ b/src/unpack_dsd.c
@@ -299,7 +299,7 @@ static int decode_fast (WavpackStream *wps, int32_t *output, int sample_count)
 
 #define RATE_S 20
 
-static void init_ptable (int *table, int rate_i, int rate_s)
+static void init_ptable (int32_t *table, int rate_i, int rate_s)
 {
     int value = 0x808000, rate = rate_i << 8, c, i;
 


### PR DESCRIPTION
```
src/pack_dsd.c: In function `encode_buffer_high':
src/pack_dsd.c:510: warning: passing arg 1 of `init_ptable' from incompatible pointer type
src/pack_dsd.c:523: warning: passing arg 1 of `normalize_ptable' from incompatible pointer type
src/pack_dsd.c:524: warning: passing arg 1 of `init_ptable' from incompatible pointer type
src/unpack_dsd.c: In function `init_dsd_block_high':
src/unpack_dsd.c:341: warning: passing arg 1 of `init_ptable' from incompatible pointer type
```

There are `-Wformat` warnings in wvpack.c and wvunpack.c in such a case,
but I didn't bother touching those.

/cc @Wohlstand
