### PR TITLE
fix signed overflow in non-syncsafe id3v2.3 frame size

### DIFF
--- a/cli/import_id3.c
+++ b/cli/import_id3.c
@@ -178,14 +178,14 @@ static int ImportID3v2_syncsafe (WavpackContext *wpc, unsigned char *tag_data, i
         if (syncsafe)
             frame_size = frame_header [7] + (frame_header [6] << 7) + (frame_header [5] << 14) + (frame_header [4] << 21);
         else
-            frame_size = frame_header [7] + (frame_header [6] << 8) + (frame_header [5] << 16) + (frame_header [4] << 24);
+            frame_size = frame_header [7] + (frame_header [6] << 8) + (frame_header [5] << 16) + ((uint32_t) frame_header [4] << 24);
 
         if (!frame_size) {
             sprintf (error, "invalid %s tag (empty frame encountered)", tag_type);
             return -1;
         }
 
-        if (frame_size > tag_size) {
+        if (frame_size < 0 || frame_size > tag_size) {
             sprintf (error, "invalid %s tag (truncated)", tag_type);
             return -1;
         }


### PR DESCRIPTION
UBSan (clang -fsanitize=shift) on an ID3v2.3 tag imported via `wvtag --import-id3`:

    cli/import_id3.c:181:116: runtime error: left shift of 255 by 24 places
      cannot be represented in type 'int'

`frame_header[4]` promotes to int, so a high size byte makes `frame_size` negative, slips past the `frame_size > tag_size` check, and reaches `memcpy(frame_body, tag_data, frame_size)` with a huge size_t. Cast the top byte like the other 32-bit assemblers in the tree and reject a negative size.
