### PR TITLE
fix signed shift overflow in WavpackOpenRawDecoder header parsing

### DIFF
--- a/src/open_raw.c
+++ b/src/open_raw.c
@@ -160,14 +160,14 @@ WavpackContext *WavpackOpenRawDecoder (
                 block_samples = *mcp++;
                 block_samples += *mcp++ << 8;
                 block_samples += *mcp++ << 16;
-                block_samples += *mcp++ << 24;
+                block_samples += (uint32_t) *mcp++ << 24;
                 main_bytes -= 4;
             }
 
             wphdr_flags = *mcp++;
             wphdr_flags += *mcp++ << 8;
             wphdr_flags += *mcp++ << 16;
-            wphdr_flags += *mcp++ << 24;
+            wphdr_flags += (uint32_t) *mcp++ << 24;
             main_bytes -= 4;
 
             // if the first block does not have the FINAL_BLOCK flag set,
@@ -179,7 +179,7 @@ WavpackContext *WavpackOpenRawDecoder (
             crc = *mcp++;
             crc += *mcp++ << 8;
             crc += *mcp++ << 16;
-            crc += *mcp++ << 24;
+            crc += (uint32_t) *mcp++ << 24;
             main_bytes -= 4;
 
             if (multiple_blocks) {
@@ -193,7 +193,7 @@ WavpackContext *WavpackOpenRawDecoder (
                 block_size = *mcp++;
                 block_size += *mcp++ << 8;
                 block_size += *mcp++ << 16;
-                block_size += *mcp++ << 24;
+                block_size += (uint32_t) *mcp++ << 24;
                 main_bytes -= 4;
             }
             else
@@ -233,7 +233,7 @@ WavpackContext *WavpackOpenRawDecoder (
                 crc = *ccp++;
                 crc += *ccp++ << 8;
                 crc += *ccp++ << 16;
-                crc += *ccp++ << 24;
+                crc += (uint32_t) *ccp++ << 24;
                 corr_bytes -= 4;
 
                 if (multiple_blocks) {
@@ -247,7 +247,7 @@ WavpackContext *WavpackOpenRawDecoder (
                     block_size = *ccp++;
                     block_size += *ccp++ << 8;
                     block_size += *ccp++ << 16;
-                    block_size += *ccp++ << 24;
+                    block_size += (uint32_t) *ccp++ << 24;
                     corr_bytes -= 4;
                 }
                 else


### PR DESCRIPTION
UBSan from clang -fsanitize=shift, driving WavpackOpenRawDecoder with Matroska-style raw blocks (no "wvpk" header) whose reconstructed header bytes have the high bit set:

    open_raw.c:163:41: runtime error: left shift of 128 by 24 places
      cannot be represented in type 'int'

The bytes promote to int before the `<< 24`, so any top byte >= 0x80 overflows the sign bit. Cast to uint32_t for the six block_samples/flags/crc/block_size fields, as WavpackLittleEndianToNative already does.