### PR TITLE
Bounds-check the bits field in legacy get_word3

### DIFF
--- a/src/unpack3.c
+++ b/src/unpack3.c
@@ -1467,6 +1467,9 @@ static int32_t FASTCALL get_word3 (WavpackStream3 *wps, int chan)
         return 0L;
 
     if (wps->wphdr.bits && dbits > wps->wphdr.bits) {
+        if (wps->wphdr.bits & ~31)
+            return WORD_EOF;
+
         getbits (&value, wps->wphdr.bits, &wps->wvbits);
 
         if (value & bitset [wps->wphdr.bits - 1])

--- a/src/unpack3.c
+++ b/src/unpack3.c
@@ -1467,9 +1467,6 @@ static int32_t FASTCALL get_word3 (WavpackStream3 *wps, int chan)
         return 0L;
 
     if (wps->wphdr.bits && dbits > wps->wphdr.bits) {
-        if (wps->wphdr.bits & ~31)
-            return WORD_EOF;
-
         getbits (&value, wps->wphdr.bits, &wps->wvbits);
 
         if (value & bitset [wps->wphdr.bits - 1])

--- a/src/unpack3_open.c
+++ b/src/unpack3_open.c
@@ -170,9 +170,9 @@ WavpackContext *open_file3 (WavpackContext *wpc, char *error)
 
     WavpackLittleEndianToNative (&wphdr, WavpackHeader3Format);
 
-    // make sure this is a version we know about
+    // make sure this is a version we know about (and valid)
 
-    if (strncmp (wphdr.ckID, "wvpk", 4) || wphdr.version < 1 || wphdr.version > 3) {
+    if (strncmp (wphdr.ckID, "wvpk", 4) || wphdr.version < 1 || wphdr.version > 3 || wphdr.bits < 0) {
         if (error) strcpy (error, "not a valid WavPack file!");
         return WavpackCloseFile (wpc);
     }


### PR DESCRIPTION
UBSan (clang -fsanitize=array-bounds), decoding a crafted version-3 file:

    src/unpack3.c:1472:21: runtime error: index -2 out of bounds for type 'const uint32_t[32]'
        #0 get_word3 unpack3.c:1472
        #1 unpack_samples3 unpack3.c:760
        #2 WavpackUnpackSamples unpack_utils.c:125

get_word3 takes the bits field straight from the version-3 header and uses it both as a getbits width and as an index into bitset/bitmask, but open_file3 never range-checks it. A negative value (e.g. 0xffff) walks off the front of the 32-entry tables. The sibling get_word1/get_old_word1 already guard their table index with `& ~31`, so I added the same guard here. Only reachable with ENABLE_LEGACY, which the fuzzer doesn't build, so I found it reading the code rather than fuzzing.