### PR TITLE
audition/cool_wv4.c: bounds-check cue/plst/ltxt special data sizes

### DIFF
--- a/audition/cool_wv4.c
+++ b/audition/cool_wv4.c
@@ -1368,10 +1368,19 @@ DWORD PASCAL FilterGetNextSpecialData (HANDLE hInput, SPECIALDATA *psp)
         }
 
         if (!strncmp (ChunkHeader.ckID, "cue ", 4)) {
-            int num_cues = (psp->dwExtra = * (DWORD *) pData);
+            int num_cues = psp->dwSize >= sizeof (DWORD) ? (psp->dwExtra = * (DWORD *) pData) : -1;
             struct cue_type *pCue = (struct cue_type *)(pData + sizeof (DWORD));
-            HANDLE hxData = GlobalAlloc (GMEM_MOVEABLE | GMEM_ZEROINIT, num_cues * 8);
-            DWORD *pdwData = (DWORD *) GlobalLock (hxData);
+            HANDLE hxData;
+            DWORD *pdwData;
+
+            if (num_cues < 0 || (DWORD) num_cues > (psp->dwSize - sizeof (DWORD)) / sizeof (struct cue_type)) {
+                GlobalUnlock (pData);
+                GlobalFree (psp->hData);
+                return 0;
+            }
+
+            hxData = GlobalAlloc (GMEM_MOVEABLE | GMEM_ZEROINIT, num_cues * 8);
+            pdwData = (DWORD *) GlobalLock (hxData);
 
             while (num_cues--) {
                 *pdwData++ = pCue->dwName;
@@ -1386,10 +1395,19 @@ DWORD PASCAL FilterGetNextSpecialData (HANDLE hInput, SPECIALDATA *psp)
             return 1;
         }
         else if (!strncmp (ChunkHeader.ckID, "plst", 4)) {
-            int num_plays = (psp->dwExtra = * (DWORD *) pData);
+            int num_plays = psp->dwSize >= sizeof (DWORD) ? (psp->dwExtra = * (DWORD *) pData) : -1;
             struct play_type *pCue = (struct play_type *)(pData + sizeof (DWORD));
-            HANDLE hxData = GlobalAlloc (GMEM_MOVEABLE | GMEM_ZEROINIT, num_plays * 16);
-            DWORD *pdwData = (DWORD *) GlobalLock (hxData);
+            HANDLE hxData;
+            DWORD *pdwData;
+
+            if (num_plays < 0 || (DWORD) num_plays > (psp->dwSize - sizeof (DWORD)) / sizeof (struct play_type)) {
+                GlobalUnlock (pData);
+                GlobalFree (psp->hData);
+                return 0;
+            }
+
+            hxData = GlobalAlloc (GMEM_MOVEABLE | GMEM_ZEROINIT, num_plays * 16);
+            pdwData = (DWORD *) GlobalLock (hxData);
 
             while (num_plays--) {
                 *pdwData++ = pCue->dwName;
@@ -1406,8 +1424,17 @@ DWORD PASCAL FilterGetNextSpecialData (HANDLE hInput, SPECIALDATA *psp)
             return 1;
         }
         else if (!strncmp (ChunkHeader.ckID, "ltxt", 4)) {
-            HANDLE hxData = GlobalAlloc (GMEM_MOVEABLE | GMEM_ZEROINIT, psp->dwSize - 4);
-            char *pxData = GlobalLock (hxData);
+            HANDLE hxData;
+            char *pxData;
+
+            if (psp->dwSize < 20) {
+                GlobalUnlock (pData);
+                GlobalFree (psp->hData);
+                return 0;
+            }
+
+            hxData = GlobalAlloc (GMEM_MOVEABLE | GMEM_ZEROINIT, psp->dwSize - 4);
+            pxData = GlobalLock (hxData);
 
             memset (pxData, 0, psp->dwSize - 4);
             * (DWORD *) pxData = psp->dwSize - 4;


### PR DESCRIPTION
Reconstructing the RIFF chunks from a file's wrapper, a crafted "cue " chunk:

    cue payload = 12 bytes, count field = 0x20000000
    -> reads 0x20000000 * 24 bytes from a 12-byte buffer
    -> GlobalAlloc(0x20000000 * 8) wraps to 0 on Win32, the loop writes 4 GiB

FilterGetNextSpecialData takes the record count straight out of the chunk payload, which comes from WavpackGetWrapperData and so is attacker controlled, then uses it as both the GlobalAlloc size and the loop bound with no check against dwSize. "plst" has the same shape. "ltxt" copies a fixed 12 bytes into a GlobalAlloc(dwSize - 4) buffer, so a dwSize below 20 overruns the destination (and below 4 underflows the size).

Found while reading the wrapper-replay path. The encode side derives the counts from dwSize, so it is safe; the decode side trusts the stored count, so it is not.

Validate each count and size against dwSize before allocating and copying.
