### PR TITLE
cli/wvunpack.c: bound dump_file_item appends to fix -f stack overflow

### DIFF
--- a/cli/wvunpack.c
+++ b/cli/wvunpack.c
@@ -3066,7 +3066,7 @@ static void dump_summary (WavpackContext *wpc, char *name, FILE *dst)
 // 9. encoding mode (in hex because it's a bitfield, always prefixed with "0x")
 // 10. filename (if available)
 
-static void dump_file_item (WavpackContext *wpc, char *str, int item_id);
+static void dump_file_item (WavpackContext *wpc, char *str, int size, int item_id);
 
 static void dump_file_info (WavpackContext *wpc, char *name, FILE *dst, int parameter)
 {
@@ -3077,8 +3077,8 @@ static void dump_file_info (WavpackContext *wpc, char *name, FILE *dst, int para
 
     if (parameter == 0) {
         for (item_id = 1; item_id <= 9; ++item_id) {
-            dump_file_item (wpc, str, item_id);
-            strcat (str, ";");
+            dump_file_item (wpc, str, sizeof (str), item_id);
+            snprintf (str + strlen (str), sizeof (str) - strlen (str), ";");
         }
 
         if (name && *name != '-')
@@ -3087,7 +3087,7 @@ static void dump_file_info (WavpackContext *wpc, char *name, FILE *dst, int para
             fprintf (dst, "%s\n", str);
     }
     else if (parameter < 10) {
-        dump_file_item (wpc, str, parameter);
+        dump_file_item (wpc, str, sizeof (str), parameter);
         fprintf (dst, "%s\n", str);
     }
     else if (parameter == 10 && name && *name != '-')
@@ -3096,34 +3096,34 @@ static void dump_file_info (WavpackContext *wpc, char *name, FILE *dst, int para
         fprintf (dst, "\n");
 }
 
-static void dump_file_item (WavpackContext *wpc, char *str, int item_id)
+static void dump_file_item (WavpackContext *wpc, char *str, int size, int item_id)
 {
     unsigned char md5_sum [16];
 
     switch (item_id) {
         case 1:
-            sprintf (str + strlen (str), "%d", raw_pcm ? WavpackGetSampleRate (wpc) : WavpackGetNativeSampleRate (wpc));
+            snprintf (str + strlen (str), size - strlen (str), "%d", raw_pcm ? WavpackGetSampleRate (wpc) : WavpackGetNativeSampleRate (wpc));
             break;
 
         case 2:
-            sprintf (str + strlen (str), "%d", ((WavpackGetQualifyMode (wpc) & QMODE_DSD_AUDIO) && !raw_pcm) ? 1 : WavpackGetBitsPerSample (wpc));
+            snprintf (str + strlen (str), size - strlen (str), "%d", ((WavpackGetQualifyMode (wpc) & QMODE_DSD_AUDIO) && !raw_pcm) ? 1 : WavpackGetBitsPerSample (wpc));
             break;
 
         case 3:
-            sprintf (str + strlen (str), "%s", (WavpackGetMode (wpc) & MODE_FLOAT) ? "float" : "int");
+            snprintf (str + strlen (str), size - strlen (str), "%s", (WavpackGetMode (wpc) & MODE_FLOAT) ? "float" : "int");
             break;
 
         case 4:
-            sprintf (str + strlen (str), "%d", WavpackGetNumChannels (wpc));
+            snprintf (str + strlen (str), size - strlen (str), "%d", WavpackGetNumChannels (wpc));
             break;
 
         case 5:
-            sprintf (str + strlen (str), "0x%x", WavpackGetChannelMask (wpc));
+            snprintf (str + strlen (str), size - strlen (str), "0x%x", WavpackGetChannelMask (wpc));
             break;
 
         case 6:
             if (WavpackGetNumSamples64 (wpc) != -1)
-                sprintf (str + strlen (str), "%lld",
+                snprintf (str + strlen (str), size - strlen (str), "%lld",
                     (long long int) WavpackGetNumSamples64 (wpc) * (WavpackGetQualifyMode (wpc) & QMODE_DSD_AUDIO ? 8 : 1));
 
             break;
@@ -3136,17 +3136,17 @@ static void dump_file_item (WavpackContext *wpc, char *str, int item_id)
                 for (i = 0; i < 16; ++i)
                     sprintf (md5_string + (i * 2), "%02x", md5_sum [i]);
 
-                sprintf (str + strlen (str), "%s", md5_string);
+                snprintf (str + strlen (str), size - strlen (str), "%s", md5_string);
             }
 
             break;
 
         case 8:
-            sprintf (str + strlen (str), "%d", WavpackGetVersion (wpc));
+            snprintf (str + strlen (str), size - strlen (str), "%d", WavpackGetVersion (wpc));
             break;
 
         case 9:
-            sprintf (str + strlen (str), "0x%x", WavpackGetMode (wpc));
+            snprintf (str + strlen (str), size - strlen (str), "0x%x", WavpackGetMode (wpc));
             break;
 
         default:


### PR DESCRIPTION
Built the cli tools with ASan and ran `-f` over a crafted file:

    ==ERROR: AddressSanitizer: stack-buffer-overflow
    WRITE of size 2 ...
        #1 dump_file_info wvunpack.c:3081
        #2 unpack_file wvunpack.c:1796
        #3 main wvunpack.c:948
      [32, 112) 'str' (line 3073) <== Memory access overflows this variable

`-f` builds a ';'-separated info line for the nine WavpackGet* fields in an 80-byte `str`. dump_file_item appends each field with `sprintf (str + strlen (str), ...)` and the loop adds a ';' with strcat, none of it bounded. The widths come straight from the .wv header. The MD5 string alone is 32 bytes (present whenever the file carries an ID_MD5_CHECKSUM block), the native sample rate and total-sample count are printed in full, and the channel mask and mode are hex.

An ordinary multichannel file with an MD5 already reaches ~72 bytes. An 18-channel float stream with a ten-digit sample rate and ~1e6 samples tips it past 80 and overruns the stack. Reachable with one command, `wvunpack -f file.wv`.

Pass the buffer size into dump_file_item and bound every append with snprintf, matching the sprintf to snprintf buffer-length fix already in xmms/src/libwavpack.c. After the patch the same file prints a truncated line and runs clean.
