### PR TITLE
src/pack_dns.c: fix out-of-bounds read in generate_dns_values

### DIFF
--- a/src/pack_dns.c
+++ b/src/pack_dns.c
@@ -243,7 +243,8 @@ static void generate_dns_values (const int32_t *samples, int sample_count, int n
     for (i = filtered_count - 1; i; --i)
         low_freq [i] -= low_freq [i - 1];
 
-    low_freq [0] = low_freq [1];    // simply duplicate for the "unknown" sample
+    if (filtered_count > 1)
+        low_freq [0] = low_freq [1];    // simply duplicate for the "unknown" sample
 
     // Next we determine the averaged (absolute) levels for each sample using a box filter.
 


### PR DESCRIPTION
Turned up while fuzzing the encoder. AddressSanitizer, compressing a 15-sample-frame stereo WAV with `wavpack -b192`:

    ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 4
        #0 generate_dns_values src/pack_dns.c
    0x602000000214 is located 0 bytes after 4-byte region [..,0x602000000214)

low_freq and high_freq are sized as filtered_count floats, and filtered_count is sample_count - FILTER_LENGTH + 1 (FILTER_LENGTH is 15). A block of exactly 15 samples makes filtered_count 1, so the delta-filter step that duplicates the unknown first sample reads low_freq[1], one float past the allocation.

Triggered by any hybrid or lossy encode whose only or final block holds 15 sample frames. With a single point there is nothing to duplicate, so the copy is guarded. Round-trips of normal and 15-frame files are unchanged.