### PR TITLE
src/common_utils.c: bound reorder copy in WavpackGetChannelLayout

### DIFF
--- a/src/common_utils.c
+++ b/src/common_utils.c
@@ -316,8 +316,17 @@ double WavpackGetInstantBitrate (WavpackContext *wpc)
 
 uint32_t WavpackGetChannelLayout (WavpackContext *wpc, unsigned char *reorder)
 {
-    if ((wpc->channel_layout & 0xff) && wpc->channel_reordering && reorder)
-        memcpy (reorder, wpc->channel_reordering, wpc->channel_layout & 0xff);
+    int nchans = wpc->channel_layout & 0xff;
+
+    // the layout channel count is read verbatim from the file metadata and is not
+    // guaranteed to match the actual channel count, so clip the reorder string to the
+    // number of channels the caller has allocated space for
+
+    if (nchans > wpc->config.num_channels)
+        nchans = wpc->config.num_channels;
+
+    if (nchans && wpc->channel_reordering && reorder)
+        memcpy (reorder, wpc->channel_reordering, nchans);
 
     return wpc->channel_layout;
 }


### PR DESCRIPTION
Turned up while fuzzing the file-open path under ASan: a crafted 2-channel file declares 255 channels in its NEW_CONFIG layout word, and WavpackGetChannelLayout copies (channel_layout & 0xff) bytes from channel_reordering. That count is taken straight from the metadata in read_new_config_info and is never checked against the real channel count.

Per the discussion, the proper fix lives at open time. read_new_config_info can't do the check itself, but by the point WavpackOpenFileInputEx64 finalises num_channels (including the MONO_FLAG fallback for files with no CHANNEL_INFO block) the channel count is known, so the layout count is verifiable there. A layout claiming more channels than the file has is invalid, so the file is rejected with "invalid channel layout in file!".

The bound added in WavpackGetChannelLayout stays as a backstop.

Fuzzer change reverted: the harness sizes its reorder buffer by the layout count, matching the library docs and the command-line tools.

Regression file fuzzing/regression/new-config-channel-reorder-overflow.wv (255-channel layout on a 2-channel file) is now rejected at open; all valid corpus files still open.