### PR TITLE
fix signed shift overflow in wvparser little_endian_to_native

### DIFF
--- a/cli/wvparser.c
+++ b/cli/wvparser.c
@@ -544,7 +544,7 @@ static void little_endian_to_native (void *data, char *format)
     while (*format) {
 	switch (*format) {
 	    case 'L':
-		temp = cp [0] + ((int32_t) cp [1] << 8) + ((int32_t) cp [2] << 16) + ((int32_t) cp [3] << 24);
+		temp = cp [0] + ((int32_t) cp [1] << 8) + ((int32_t) cp [2] << 16) + ((uint32_t) cp [3] << 24);
 		* (int32_t *) cp = temp;
 		cp += 4;
 		break;

--- a/cli/wvparser.c
+++ b/cli/wvparser.c
@@ -544,7 +544,7 @@ static void little_endian_to_native (void *data, char *format)
     while (*format) {
 	switch (*format) {
 	    case 'L':
-		temp = cp [0] + ((int32_t) cp [1] << 8) + ((int32_t) cp [2] << 16) + ((uint32_t) cp [3] << 24);
+		temp = (uint32_t) cp [0] + ((uint32_t) cp [1] << 8) + ((uint32_t) cp [2] << 16) + ((uint32_t) cp [3] << 24);
 		* (int32_t *) cp = temp;
 		cp += 4;
 		break;


### PR DESCRIPTION
UBSan, clang -fsanitize=undefined, feeding a crafted .wv to wvparser on stdin:

    cli/wvparser.c:547:90: runtime error: left shift of 128 by 24 places cannot be represented in type 'int32_t' (aka 'int')

little_endian_to_native builds a 32-bit "L" field as cp[0] + (cp[1]<<8) + (cp[2]<<16) + ((int32_t) cp[3] << 24). The top byte promotes to signed int, so any value >= 0x80 overflows the sign bit. read_next_header constrains the ckSize bytes but not the later header fields (total_samples, block_index, flags, crc), so a single ordinary block trips it.

Found it diffing this self-contained parser against WavpackLittleEndianToNative in src/common_utils.c, which casts the top byte to int64_t to avoid exactly this; tag_utils.c uses uint32_t. wvparser was the last reader still on the signed form. Cast cp[3] to uint32_t to match.