### PR TITLE
cli/caff.c, cli/aiff.c: reject non-finite sample rate before int cast

### DIFF
--- a/cli/aiff.c
+++ b/cli/aiff.c
@@ -194,7 +194,7 @@ int ParseAiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
             else if (strncmp (common_chunk.compressionType, "SOWT", 4) && strncmp (common_chunk.compressionType, "sowt", 4))
                 supported = FALSE;
 
-            if (sampleRate <= 0.0 || sampleRate > 16777215.0)
+            if (!(sampleRate > 0.0 && sampleRate <= 16777215.0))
                 supported = FALSE;
 
             if (floatData && common_chunk.sampleSize != 32)

--- a/cli/caff.c
+++ b/cli/caff.c
@@ -227,7 +227,7 @@ int ParseCaffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
 
             if (strncmp (caf_audio_format.mFormatID, "lpcm", 4) || (caf_audio_format.mFormatFlags & ~3))
                 supported = FALSE;
-            else if (caf_audio_format.mSampleRate <= 0.0 || caf_audio_format.mSampleRate > 16777215.0)
+            else if (!(caf_audio_format.mSampleRate > 0.0 && caf_audio_format.mSampleRate <= 16777215.0))
                 supported = FALSE;
             else if (!caf_audio_format.mChannelsPerFrame || caf_audio_format.mChannelsPerFrame > WAVPACK_MAX_CLI_CHANS)
                 supported = FALSE;


### PR DESCRIPTION
UBSan, clang -fsanitize=undefined, running the file-format parsers on crafted input:

    cli/caff.c:262:39: runtime error: nan is outside the range of representable values of type 'int'
    cli/aiff.c:220:39: runtime error: nan is outside the range of representable values of type 'int'

ParseCaffHeaderConfig and ParseAiffHeaderConfig gate the sample rate with `rate <= 0.0 || rate > 16777215.0`, then convert it with `(int) floor (rate + 0.5)`. Every comparison against NaN is false, so a NaN rate walks straight past the gate into the cast, which is undefined.

For CAF the rate is an IEEE double copied verbatim from the 'desc' chunk, so the NaN is supplied directly. For AIFF it is the 80-bit extended value in COMM; a zero mantissa with a maximal exponent gives 0 * inf = NaN. Both are reachable from `wavpack file.caf` / `wavpack file.aif`, which the fuzzer does not exercise.

Requiring a finite in-range value rejects the file before the cast. For finite rates the new test is the same range, so valid input behaves exactly as before.