### PR TITLE
cli: strip path separators from extracted binary tag filenames

### DIFF
--- a/cli/wvtag.c
+++ b/cli/wvtag.c
@@ -1312,7 +1312,14 @@ static int dump_tag_item_to_file (WavpackContext *wpc, const char *tag_item, FIL
                     }
 
                     if (fname) {
-                        char *sanitized_tag_value = filespec_name (value) ? filespec_name (value) : value;
+                        char *sanitized_tag_value = value, *cp;
+
+                        // the embedded filename comes from untrusted tag data; strip any
+                        // path prefix using either separator (filespec_name() only removes
+                        // the native one) so the file can't be written outside the target
+                        for (cp = value; *cp; ++cp)
+                            if (*cp == '\\' || *cp == '/')
+                                sanitized_tag_value = cp + 1;
 
                         if (strlen (sanitized_tag_value) < 256)
                             strcpy (fname, sanitized_tag_value);

--- a/cli/wvunpack.c
+++ b/cli/wvunpack.c
@@ -3217,7 +3217,14 @@ static int dump_tag_item_to_file (WavpackContext *wpc, const char *tag_item, FIL
                     }
 
                     if (fname) {
-                        char *sanitized_tag_value = filespec_name (value) ? filespec_name (value) : value;
+                        char *sanitized_tag_value = value, *cp;
+
+                        // the embedded filename comes from untrusted tag data; strip any
+                        // path prefix using either separator (filespec_name() only removes
+                        // the native one) so the file can't be written outside the target
+                        for (cp = value; *cp; ++cp)
+                            if (*cp == '\\' || *cp == '/')
+                                sanitized_tag_value = cp + 1;
 
                         if (strlen (sanitized_tag_value) < 256)
                             strcpy (fname, sanitized_tag_value);


### PR DESCRIPTION
Extracting a binary tag item to a file (cover art, `wvunpack -xx "Field=%t"`) names the output after the item's embedded filename. That name is untrusted: it is the tag value bytes up to the first NUL, straight from the .wv/APEv2 tag. dump_tag_item_to_file() runs it through filespec_name() first, but filespec_name() only removes the platform's native separator:

    embedded name:  ../../../../../ab.jpg
    filespec_name(), _WIN32 build  ->  ../../../../../ab.jpg
    filespec_name(), POSIX build   ->  ab.jpg

Windows treats both `/` and `\` as separators, so on Windows a forward-slash name passes through unchanged and reaches fopen() as the output name, writing the file above the target directory. POSIX has the mirror gap: an embedded `\` survives (harmless there, but it is the same routine). I found it by crafting a cover-art tag whose embedded name held separators and watching where the extracted file landed.

Reduce the embedded name to its final component, checking both separators, before it becomes the output name. Normal filenames are unaffected. wvtag keeps an identical copy of the function and is fixed the same way.