### PR TITLE
Reject invalid raw decoder buffer lengths

### DIFF
--- a/src/open_raw.c
+++ b/src/open_raw.c
@@ -137,6 +137,11 @@ WavpackContext *WavpackOpenRawDecoder (
 {
     WavpackRawContext *raw_wv = NULL, *raw_wvc = NULL;
 
+    if (!main_data || main_size < 4 || corr_size < 0 || (corr_size && !corr_data)) {
+        if (error) strcpy (error, "invalid raw buffer(s) provided!");
+        return NULL;
+    }
+
     // if the WavPack data does not contain headers we assume Matroska-style storage
     // and recreate the missing headers
 
@@ -326,4 +331,3 @@ uint32_t WavpackGetNumSamplesInFrame (WavpackContext *wpc)
     else
         return -1;
 }
-


### PR DESCRIPTION
WavpackOpenRawDecoder compared the raw signature before checking the main buffer length. A truncated raw frame could read beyond the caller-provided buffer and crash an application decoding untrusted media.

Validate main and correction buffer arguments before parsing. This rejects missing or too-short main buffers, negative correction lengths, and nonzero correction lengths without a correction buffer.

Verified with ASan/UBSan, the truncated-frame reproducer, invalid correction-buffer inputs, targeted raw-frame fuzzing, and the existing regression corpus.